### PR TITLE
Allow for nonexistent boundary

### DIFF
--- a/boundary.go
+++ b/boundary.go
@@ -109,15 +109,15 @@ func (b *boundaryReader) Next() (bool, error) {
 			b.partsRead++
 			return true, nil
 		}
+		if err == io.EOF {
+			return false, io.EOF
+		}
 		if b.partsRead == 0 {
 			// The first part didn't find the starting delimiter, burn off any preamble in front of
 			// the boundary
 			continue
 		}
 		b.finished = true
-		if err == io.EOF {
-			return false, io.ErrUnexpectedEOF
-		}
 		return false, fmt.Errorf("expecting boundary %q, got %q", string(b.prefix), string(line))
 	}
 }

--- a/boundary_test.go
+++ b/boundary_test.go
@@ -228,3 +228,19 @@ func TestBoundaryReaderPartialRead(t *testing.T) {
 		}
 	}
 }
+
+func TestBoundaryReaderNoMatch(t *testing.T) {
+	input := "\r\n--STOPHERE\r\n1111\r\n--STOPHERE\r\n2222\r\n--STOPHERE\r\n"
+	boundary := "NOMATCH"
+
+	ir := bufio.NewReader(strings.NewReader(input))
+	br := newBoundaryReader(ir, boundary)
+
+	next, err := br.Next()
+	if err != io.EOF {
+		t.Fatalf("err = %v, want: io.EOF", err)
+	}
+	if next {
+		t.Fatalf("Next() = true, want: false")
+	}
+}


### PR DESCRIPTION
When attempting to parse a multipart email where the boundary doesn't exist, enmime gets stuck in an infinite loop.

I have created a test and implemented a fix. Feel free to reject and implement in your own manner! :)
