### PR TITLE
Missing body

### DIFF
--- a/envelope_test.go
+++ b/envelope_test.go
@@ -536,6 +536,21 @@ func TestParseEncodedAddressList(t *testing.T) {
 	if got != want {
 		t.Errorf("To was: %q, want: %q", got, want)
 	}
+
+	senderAddresses, err := e.AddressList("Sender")
+	if err != nil {
+		t.Fatal("Failed to parse Sender list:", err)
+	}
+	if len(senderAddresses) != 1 {
+		t.Fatalf("len(senderAddresses) == %v, want: %v", len(senderAddresses), 1)
+	}
+
+	// Confirm address name was decoded properly
+	want = "André Pirard"
+	got = senderAddresses[0].Name
+	if got != want {
+		t.Errorf("Sender was: %q, want: %q", got, want)
+	}
 }
 
 func TestDetectCharacterSetInHTML(t *testing.T) {

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -67,6 +67,7 @@ func TestIdentifyBinaryBody(t *testing.T) {
 
 func TestParseHeaderOnly(t *testing.T) {
 	want := ""
+
 	msg := openTestData("mail", "header-only.raw")
 	e, err := ReadEnvelope(msg)
 
@@ -78,6 +79,12 @@ func TestParseHeaderOnly(t *testing.T) {
 	}
 	if e.HTML != "" {
 		t.Errorf("Expected no HTML body, got %q", e.HTML)
+	}
+	if e.Root == nil {
+		t.Errorf("Expected a root part")
+	}
+	if len(e.Root.Header) != 7 {
+		t.Errorf("Expected 7 headers, got %d", len(e.Root.Header))
 	}
 }
 

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -65,6 +65,22 @@ func TestIdentifyBinaryBody(t *testing.T) {
 	}
 }
 
+func TestParseHeaderOnly(t *testing.T) {
+	want := ""
+	msg := openTestData("mail", "header-only.raw")
+	e, err := ReadEnvelope(msg)
+
+	if err != nil {
+		t.Fatal("Failed to parse non-MIME:", err)
+	}
+	if !strings.Contains(e.Text, want) {
+		t.Errorf("Expected %q to contain %q", e.Text, want)
+	}
+	if e.HTML != "" {
+		t.Errorf("Expected no HTML body, got %q", e.HTML)
+	}
+}
+
 func TestParseNonMime(t *testing.T) {
 	want := "This is a test mailing"
 	msg := openTestData("mail", "non-mime.raw")

--- a/example_test.go
+++ b/example_test.go
@@ -47,7 +47,7 @@ func Example() {
 	fmt.Printf("Attachments: %v\n", len(env.Attachments))
 
 	// Output:
-	// From: James Hillyerd <jamehi03@jamehi03lx.noa.com>
+	// From: James Hillyerd <jamehi03@jamehi03lx.noa.com>, André Pirard <PIRARD@vm1.ulg.ac.be>
 	// To: Mirosław Marczak <marczak@inbucket.com>
 	// Subject: MIME UTF8 Test ¢ More Text
 	// Text Body: 1300 chars

--- a/header.go
+++ b/header.go
@@ -86,6 +86,7 @@ func readHeader(r *bufio.Reader, p *Part) (textproto.MIMEHeader, error) {
 			if err == io.ErrUnexpectedEOF && buf.Len() == 0 {
 				return nil, errEmptyHeaderBlock
 			} else if err == io.EOF {
+				buf.Write([]byte{'\r', '\n'})
 				break
 			}
 			return nil, err
@@ -117,12 +118,12 @@ func readHeader(r *bufio.Reader, p *Part) (textproto.MIMEHeader, error) {
 				} else {
 					// Empty line, finish header parsing
 					buf.Write([]byte{'\r', '\n'})
-					buf.Write([]byte{'\r', '\n'})
 					break
 				}
 			}
 		}
 	}
+	buf.Write([]byte{'\r', '\n'})
 	tr := textproto.NewReader(bufio.NewReader(buf))
 	header, err := tr.ReadMIMEHeader()
 	return header, err

--- a/header.go
+++ b/header.go
@@ -41,12 +41,19 @@ var errEmptyHeaderBlock = errors.New("empty header block")
 // AddressHeaders is the set of SMTP headers that contain email addresses, used by
 // Envelope.AddressList().  Key characters must be all lowercase.
 var AddressHeaders = map[string]bool{
-	"bcc":          true,
-	"cc":           true,
-	"delivered-to": true,
-	"from":         true,
-	"reply-to":     true,
-	"to":           true,
+	"bcc":             true,
+	"cc":              true,
+	"delivered-to":    true,
+	"from":            true,
+	"reply-to":        true,
+	"to":              true,
+	"sender":          true,
+	"resent-bcc":      true,
+	"resent-cc":       true,
+	"resent-from":     true,
+	"resent-reply-to": true,
+	"resent-to":       true,
+	"resent-sender":   true,
 }
 
 func debug(format string, args ...interface{}) {

--- a/header_test.go
+++ b/header_test.go
@@ -159,13 +159,74 @@ func TestDecodeToUTF8Base64Header(t *testing.T) {
 }
 
 func TestReadHeader(t *testing.T) {
-	prefix := "From: hooman\n"
+	prefix := "From: hooman\n \n being\n"
 	suffix := "Subject: hi\n\nPart body\n"
 
+	data := make([]byte, 16*1024)
+	for i := 0; i < len(data); i++ {
+		data[i] = 'x'
+	}
+	sdata := string(data)
+	_ = sdata
+	/*
+		"Foo: bar\r\n" +
+				"Content-Language: en\r\n" +
+				"SID : 0\r\n" +
+				"Audio Mode : None\r\n" +
+				"Privilege : 127\r\n\r\n"
+	*/
 	var ttable = []struct {
 		input, hname, want string
 		correct            bool
 	}{
+		{
+			input:   "Foo: bar\r\n",
+			hname:   "Foo",
+			want:    "bar",
+			correct: true,
+		},
+		{
+			input:   "Content-Language: en\r\n",
+			hname:   "Content-Language",
+			want:    "en",
+			correct: true,
+		},
+		{
+			input:   "SID : 0\r\n",
+			hname:   "SID",
+			want:    "0",
+			correct: true,
+		},
+		{
+			input:   "Audio Mode : None\r\n",
+			hname:   "Audio Mode",
+			want:    "None",
+			correct: true,
+		},
+		{
+			input:   "Privilege : 127\r\n",
+			hname:   "Privilege",
+			want:    "127",
+			correct: true,
+		},
+		{
+			input:   "Cookie: " + sdata + "\r\n",
+			hname:   "Cookie",
+			want:    sdata,
+			correct: true,
+		},
+		{
+			input:   ": line1=foo\r\n",
+			hname:   "",
+			want:    "",
+			correct: true,
+		},
+		{
+			input:   "X-Continuation: line1=foo\r\n \r\n line2=bar\r\n",
+			hname:   "X-Continuation",
+			want:    "line1=foo  line2=bar",
+			correct: true,
+		},
 		{
 			input:   "To: anybody\n",
 			hname:   "To",
@@ -175,19 +236,25 @@ func TestReadHeader(t *testing.T) {
 		{
 			input:   "Content-Type: text/plain;\n charset=us-ascii\n",
 			hname:   "Content-Type",
-			want:    "text/plain;charset=us-ascii",
+			want:    "text/plain; charset=us-ascii",
 			correct: true,
 		},
 		{
 			input:   "X-Tabbed-Continuation: line1=foo;\n\tline2=bar\n",
 			hname:   "X-Tabbed-Continuation",
-			want:    "line1=foo;line2=bar",
+			want:    "line1=foo; line2=bar",
 			correct: true,
 		},
 		{
-			input:   "X-Bad-Continuation: line1=foo;\nline2=bar; name=value:text\n",
+			input:   "name=value:text\n",
+			hname:   "name=value",
+			want:    "text",
+			correct: true,
+		},
+		{
+			input:   "X-Bad-Continuation: line1=foo;\nline2=bar\n",
 			hname:   "X-Bad-Continuation",
-			want:    "line1=foo;line2=bar;name=value:text",
+			want:    "line1=foo; line2=bar",
 			correct: false,
 		},
 		{
@@ -210,7 +277,7 @@ func TestReadHeader(t *testing.T) {
 
 		// Check prefix
 		got := header.Get("From")
-		want := "hooman"
+		want := "hooman  being"
 		if got != want {
 			t.Errorf("From header got: %q, want: %q\ninput: %q", got, want, tt.input)
 		}
@@ -221,7 +288,7 @@ func TestReadHeader(t *testing.T) {
 			t.Errorf("Subject header got: %q, want: %q\ninput: %q", got, want, tt.input)
 		}
 		// Check ttable
-		got = strings.Replace(header.Get(tt.hname), " ", "", -1)
+		got = header.Get(tt.hname)
 		if got != tt.want {
 			t.Errorf(
 				"Stripped %s value got: %q, want: %q\ninput: %q", tt.hname, got, tt.want, tt.input)

--- a/part.go
+++ b/part.go
@@ -169,7 +169,7 @@ func parseParts(parent *Part, reader *bufio.Reader, boundary string) error {
 	br := newBoundaryReader(reader, boundary)
 	for {
 		next, err := br.Next()
-		if err != nil {
+		if err != nil && err != io.EOF {
 			return err
 		}
 		if !next {

--- a/testdata/mail/header-only.raw
+++ b/testdata/mail/header-only.raw
@@ -1,0 +1,7 @@
+From: James Hillyerd <james@makita.skynet>
+Subject: Attachment
+Date: Thu, 18 Oct 2012 22:48:39 -0700
+Message-Id: <07B7061D-2676-487E-942E-C341CE4D13DC@makita.skynet>
+To: greg@inbucket
+Mime-Version: 1.0 
+Content-Type: multipart/mixed; boundary="Enmime-Test-100"

--- a/testdata/mail/qp-utf8-header.raw
+++ b/testdata/mail/qp-utf8-header.raw
@@ -1,6 +1,7 @@
 Message-ID: <5081A889.3020108@jamehi03lx.noa.com>
 Date: Fri, 19 Oct 2012 12:22:49 -0700
-From: James Hillyerd <jamehi03@jamehi03lx.noa.com>
+From: James Hillyerd <jamehi03@jamehi03lx.noa.com>, =?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>
+Sender: =?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>
 User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0) Gecko/20121010 Thunderbird/16.0.1
 MIME-Version: 1.0
 To: =?UTF-8?Q?Miros=C5=82aw_Marczak?= <marczak@inbucket.com>


### PR DESCRIPTION
We have a case where we only have the message headers, and not the body. The std library mail.ParseMessage handles this by requiring a separate step to parse the body.

Added handling for this situation along with tests. All existing tests still pass.