### PR TITLE
Fix for certain charset duplicate params error

### DIFF
--- a/envelope_test.go
+++ b/envelope_test.go
@@ -797,3 +797,16 @@ func TestEnvelopeParseMultiPartBody(t *testing.T) {
 		t.Fatalf("err was %v, wanted: %v", err, want)
 	}
 }
+
+func TestDuplicateParamsInMime(t *testing.T) {
+	msg := openTestData("mail", "mime-duplicate-param.raw")
+	e, err := ReadEnvelope(msg)
+
+	if err != nil {
+		t.Fatal("Failed to parse MIME:", err)
+	}
+
+	if e.Attachments[0].FileName != "Invoice_302232133150612.pdf" {
+		t.Fatal("Mail should have a part with filename Invoice_302232133150612.pdf")
+	}
+}

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -823,3 +823,16 @@ func TestBadContentTypeInMime(t *testing.T) {
 		t.Fatal("Mail should have a part with filename Invoice_302232133150612.pdf")
 	}
 }
+
+func TestBlankMediaName(t *testing.T) {
+	msg := openTestData("mail", "mime-blank-media-name.raw")
+	e, err := ReadEnvelope(msg)
+
+	if err != nil {
+		t.Fatal("Failed to parse MIME:", err)
+	}
+
+	if e.Attachments[0].FileName != "Invoice_302232133150612.pdf" {
+		t.Fatal("Mail should have a part with filename Invoice_302232133150612.pdf")
+	}
+}

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -810,3 +810,16 @@ func TestDuplicateParamsInMime(t *testing.T) {
 		t.Fatal("Mail should have a part with filename Invoice_302232133150612.pdf")
 	}
 }
+
+func TestBadContentTypeInMime(t *testing.T) {
+	msg := openTestData("mail", "mime-bad-content-type.raw")
+	e, err := ReadEnvelope(msg)
+
+	if err != nil {
+		t.Fatal("Failed to parse MIME:", err)
+	}
+
+	if e.Attachments[0].FileName != "Invoice_302232133150612.pdf" {
+		t.Fatal("Mail should have a part with filename Invoice_302232133150612.pdf")
+	}
+}

--- a/testdata/mail/mime-bad-content-type.raw
+++ b/testdata/mail/mime-bad-content-type.raw
@@ -1,0 +1,91 @@
+From: "easyHotel Booking" <bookings@easyHotel.com>
+To: <deepak.prabhakara@gmail.com>
+Subject: Confirmation of Booking with easyHotel
+Date: Fri, 12 Jun 2015 23:24:01 +0100
+Message-ID: <F21768750C2E4303B37CA8EDCD498C67@dm3.entee.co.uk>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="----=_NextPart_000_057C_01D0A566.DD8BD380"
+X-Mailer: Microsoft CDO for Windows 2000
+Content-Class: urn:content-classes:message
+Importance: normal
+Priority: normal
+X-MimeOLE: Produced By Microsoft MimeOLE V6.1.7601.17609
+Return-Path: bookings@easyHotel.com
+X-OriginalArrivalTime: 12 Jun 2015 22:24:01.0592 (UTC)
+
+    FILETIME=[7BC76B80:01D0A55E]
+
+
+
+This is a multi-part message in MIME format.
+
+
+
+------=_NextPart_000_057C_01D0A566.DD8BD380
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+
+
+Thank you for booking with easyHotel.
+
+
+
+You may review your booking details here: 
+
+https://bookings.easyHotel.com/AccClient/MyInformation-MyBookings.asp
+
+
+
+You may review your account including payment information here: 
+
+https://bookings.easyHotel.com/AccClient/MyInformation-MyAccount.asp
+
+
+
+You may obtain general help and assistance here: 
+
+http://support.easyhotel.com/hc/en-gb/categories/200490531-Frequently-asked-questions
+
+
+
+You can review our terms and conditions (including refund policy) again here: 
+
+https://bookings.easyhotel.com/secbook/GB/tandc.html
+
+
+
+You will need Adobe Acrobat Reader to open the attached invoice. If you do not already have it installed on your computer, you can download it free of charge from  http://get.adobe.com/uk/reader/
+
+
+
+
+
+We wish you a pleasant stay.
+
+
+
+easyHotel
+
+
+
+------=_NextPart_000_057C_01D0A566.DD8BD380
+Content-Type: application/pdf name="Invoice_302232133150612.pdf"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="Invoice_302232133150612.pdf"
+
+
+
+JVBERi0xLjINCg0KNCAwIG9iag0KPDwNCi9FIDYxOTUNCi9IIFsgMTIxMSAxNDUgXQ0KL0wgNjUy
+MA0KL0xpbmVhcml6ZWQgMQ0KL04gMQ0KL08gNw0KL1QgNjM5MA0KPj4gICAgICAgICAgICAgICAg
+ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
+DQplbmRvYmoNCg0KeHJlZg0KNCA4DQowMDAwMDAwMDEyIDAwMDAwIG4NCjAwMDAwMDEwODggMDAw
+MDAgbg0KMDAwMDAwMTIxMSAwMDAwMCBuDQowMDAwMDAxMzU2IDAwMDAwIG4NCjAwMDAwMDE2MDcg
+MDAwMDAgbg0KMDAwMDAwMTcxNiAwMDAwMCBuDQowMDAwMDAxODI0IDAwMDAwIG4NCjAwMDAwMDQz
+MTkgMDAwMDAgbg0KdHJhaWxlcg0KPDwNCi9BQkNwZGYgODEwNw0KL0lEIFsgPDNENzc5REU2NjU0
+RDM4ODczMTYzODBBNTY3REY0MDhFPg0KPDc5OEQ0RjVGNkUyNzIzQjA1MTFCQzU0QzYwMTczRDI3
+PiBdDQovSW5mbyAzIDAgUg0KL1ByZXYgNjM4MA0KL1Jvb3QgNSAwIFINCi9TaXplIDEyDQovU291
+cmNlIChXZUpYRnh
+
+------=_NextPart_000_057C_01D0A566.DD8BD380--
+

--- a/testdata/mail/mime-blank-media-name.raw
+++ b/testdata/mail/mime-blank-media-name.raw
@@ -1,0 +1,91 @@
+From: "easyHotel Booking" <bookings@easyHotel.com>
+To: <deepak.prabhakara@gmail.com>
+Subject: Confirmation of Booking with easyHotel
+Date: Fri, 12 Jun 2015 23:24:01 +0100
+Message-ID: <F21768750C2E4303B37CA8EDCD498C67@dm3.entee.co.uk>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="----=_NextPart_000_057C_01D0A566.DD8BD380"
+X-Mailer: Microsoft CDO for Windows 2000
+Content-Class: urn:content-classes:message
+Importance: normal
+Priority: normal
+X-MimeOLE: Produced By Microsoft MimeOLE V6.1.7601.17609
+Return-Path: bookings@easyHotel.com
+X-OriginalArrivalTime: 12 Jun 2015 22:24:01.0592 (UTC)
+
+    FILETIME=[7BC76B80:01D0A55E]
+
+
+
+This is a multi-part message in MIME format.
+
+
+
+------=_NextPart_000_057C_01D0A566.DD8BD380
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+
+
+Thank you for booking with easyHotel.
+
+
+
+You may review your booking details here: 
+
+https://bookings.easyHotel.com/AccClient/MyInformation-MyBookings.asp
+
+
+
+You may review your account including payment information here: 
+
+https://bookings.easyHotel.com/AccClient/MyInformation-MyAccount.asp
+
+
+
+You may obtain general help and assistance here: 
+
+http://support.easyhotel.com/hc/en-gb/categories/200490531-Frequently-asked-questions
+
+
+
+You can review our terms and conditions (including refund policy) again here: 
+
+https://bookings.easyhotel.com/secbook/GB/tandc.html
+
+
+
+You will need Adobe Acrobat Reader to open the attached invoice. If you do not already have it installed on your computer, you can download it free of charge from  http://get.adobe.com/uk/reader/
+
+
+
+
+
+We wish you a pleasant stay.
+
+
+
+easyHotel
+
+
+
+------=_NextPart_000_057C_01D0A566.DD8BD380
+Content-Type: application/pdf name=""
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="Invoice_302232133150612.pdf"
+
+
+
+JVBERi0xLjINCg0KNCAwIG9iag0KPDwNCi9FIDYxOTUNCi9IIFsgMTIxMSAxNDUgXQ0KL0wgNjUy
+MA0KL0xpbmVhcml6ZWQgMQ0KL04gMQ0KL08gNw0KL1QgNjM5MA0KPj4gICAgICAgICAgICAgICAg
+ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
+DQplbmRvYmoNCg0KeHJlZg0KNCA4DQowMDAwMDAwMDEyIDAwMDAwIG4NCjAwMDAwMDEwODggMDAw
+MDAgbg0KMDAwMDAwMTIxMSAwMDAwMCBuDQowMDAwMDAxMzU2IDAwMDAwIG4NCjAwMDAwMDE2MDcg
+MDAwMDAgbg0KMDAwMDAwMTcxNiAwMDAwMCBuDQowMDAwMDAxODI0IDAwMDAwIG4NCjAwMDAwMDQz
+MTkgMDAwMDAgbg0KdHJhaWxlcg0KPDwNCi9BQkNwZGYgODEwNw0KL0lEIFsgPDNENzc5REU2NjU0
+RDM4ODczMTYzODBBNTY3REY0MDhFPg0KPDc5OEQ0RjVGNkUyNzIzQjA1MTFCQzU0QzYwMTczRDI3
+PiBdDQovSW5mbyAzIDAgUg0KL1ByZXYgNjM4MA0KL1Jvb3QgNSAwIFINCi9TaXplIDEyDQovU291
+cmNlIChXZUpYRnh
+
+------=_NextPart_000_057C_01D0A566.DD8BD380--
+

--- a/testdata/mail/mime-duplicate-param.raw
+++ b/testdata/mail/mime-duplicate-param.raw
@@ -1,0 +1,91 @@
+From: "easyHotel Booking" <bookings@easyHotel.com>
+To: <deepak.prabhakara@gmail.com>
+Subject: Confirmation of Booking with easyHotel
+Date: Fri, 12 Jun 2015 23:24:01 +0100
+Message-ID: <F21768750C2E4303B37CA8EDCD498C67@dm3.entee.co.uk>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="----=_NextPart_000_057C_01D0A566.DD8BD380"
+X-Mailer: Microsoft CDO for Windows 2000
+Content-Class: urn:content-classes:message
+Importance: normal
+Priority: normal
+X-MimeOLE: Produced By Microsoft MimeOLE V6.1.7601.17609
+Return-Path: bookings@easyHotel.com
+X-OriginalArrivalTime: 12 Jun 2015 22:24:01.0592 (UTC)
+
+    FILETIME=[7BC76B80:01D0A55E]
+
+
+
+This is a multi-part message in MIME format.
+
+
+
+------=_NextPart_000_057C_01D0A566.DD8BD380
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+
+
+Thank you for booking with easyHotel.
+
+
+
+You may review your booking details here: 
+
+https://bookings.easyHotel.com/AccClient/MyInformation-MyBookings.asp
+
+
+
+You may review your account including payment information here: 
+
+https://bookings.easyHotel.com/AccClient/MyInformation-MyAccount.asp
+
+
+
+You may obtain general help and assistance here: 
+
+http://support.easyhotel.com/hc/en-gb/categories/200490531-Frequently-asked-questions
+
+
+
+You can review our terms and conditions (including refund policy) again here: 
+
+https://bookings.easyhotel.com/secbook/GB/tandc.html
+
+
+
+You will need Adobe Acrobat Reader to open the attached invoice. If you do not already have it installed on your computer, you can download it free of charge from  http://get.adobe.com/uk/reader/
+
+
+
+
+
+We wish you a pleasant stay.
+
+
+
+easyHotel
+
+
+
+------=_NextPart_000_057C_01D0A566.DD8BD380
+Content-Type: application/pdf; name="Invoice_302232133150612.pdf"; name="Invoice_302232133150612.pdf"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="Invoice_302232133150612.pdf"
+
+
+
+JVBERi0xLjINCg0KNCAwIG9iag0KPDwNCi9FIDYxOTUNCi9IIFsgMTIxMSAxNDUgXQ0KL0wgNjUy
+MA0KL0xpbmVhcml6ZWQgMQ0KL04gMQ0KL08gNw0KL1QgNjM5MA0KPj4gICAgICAgICAgICAgICAg
+ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
+DQplbmRvYmoNCg0KeHJlZg0KNCA4DQowMDAwMDAwMDEyIDAwMDAwIG4NCjAwMDAwMDEwODggMDAw
+MDAgbg0KMDAwMDAwMTIxMSAwMDAwMCBuDQowMDAwMDAxMzU2IDAwMDAwIG4NCjAwMDAwMDE2MDcg
+MDAwMDAgbg0KMDAwMDAwMTcxNiAwMDAwMCBuDQowMDAwMDAxODI0IDAwMDAwIG4NCjAwMDAwMDQz
+MTkgMDAwMDAgbg0KdHJhaWxlcg0KPDwNCi9BQkNwZGYgODEwNw0KL0lEIFsgPDNENzc5REU2NjU0
+RDM4ODczMTYzODBBNTY3REY0MDhFPg0KPDc5OEQ0RjVGNkUyNzIzQjA1MTFCQzU0QzYwMTczRDI3
+PiBdDQovSW5mbyAzIDAgUg0KL1ByZXYgNjM4MA0KL1Jvb3QgNSAwIFINCi9TaXplIDEyDQovU291
+cmNlIChXZUpYRnh
+
+------=_NextPart_000_057C_01D0A566.DD8BD380--
+


### PR DESCRIPTION
If a duplicate param is present then parsing of the entire email fails. This fix handles a misplaced ";" in content-type. It also handles empty name in content-type. I have also added a unit test for this scenario.
