### PR TITLE
Handle unencoded equals in quoted printable sanitizer

### DIFF
--- a/part.go
+++ b/part.go
@@ -86,7 +86,7 @@ func (p *Part) buildContentReaders(r io.Reader) error {
 	encoding := p.Header.Get(hnContentEncoding)
 	switch strings.ToLower(encoding) {
 	case "quoted-printable":
-		contentReader = newQPCleaner(contentReader.(io.ByteReader))
+		contentReader = newQPCleaner(contentReader)
 		contentReader = quotedprintable.NewReader(contentReader)
 	case "base64":
 		contentReader = newBase64Cleaner(contentReader)

--- a/quotedprint.go
+++ b/quotedprint.go
@@ -1,6 +1,7 @@
 package enmime
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 )
@@ -8,7 +9,7 @@ import (
 // qpCleaner scans quoted printable content for invalid characters and encodes them so that
 // Go's quoted-printable decoder does not abort with an error.
 type qpCleaner struct {
-	in io.ByteReader
+	in *bufio.Reader
 }
 
 // Assert qpCleaner implements io.Reader
@@ -16,9 +17,9 @@ var _ io.Reader = &qpCleaner{}
 
 // newBase64Cleaner returns a Base64Cleaner object for the specified reader.  Base64Cleaner
 // implements the io.Reader interface.
-func newQPCleaner(r io.ByteReader) *qpCleaner {
+func newQPCleaner(r io.Reader) *qpCleaner {
 	return &qpCleaner{
-		in: r,
+		in: bufio.NewReader(r),
 	}
 }
 
@@ -34,6 +35,21 @@ func (qp *qpCleaner) Read(dest []byte) (n int, err error) {
 		}
 		// Test character type
 		switch {
+		case b == '=':
+			// pass valid hex bytes through
+			hexBytes, err := qp.in.Peek(2)
+			if err != nil {
+				if err != io.EOF {
+					return 0, err
+				}
+			}
+			if isValidHexBytes(hexBytes) {
+				dest[n] = b
+				n++
+			} else {
+				s := fmt.Sprintf("=%02X", b)
+				n += copy(dest[n:], s)
+			}
 		case b == '\t' || b == '\r' || b == '\n':
 			// Valid special characters
 			dest[n] = b
@@ -49,4 +65,43 @@ func (qp *qpCleaner) Read(dest []byte) (n int, err error) {
 		}
 	}
 	return
+}
+
+func isValidHexByte(b byte) bool {
+	switch {
+	case b >= '0' && b <= '9':
+		return true
+	case b >= 'A' && b <= 'F':
+		return true
+	// Accept badly encoded bytes.
+	case b >= 'a' && b <= 'f':
+		return true
+	}
+	return false
+}
+
+func isValidHexBytes(v []byte) bool {
+	if len(v) < 1 {
+		return false
+	}
+
+	// soft line break
+	if v[0] == '\n' {
+		return true
+	}
+
+	if len(v) < 2 {
+		return false
+	}
+
+	// soft line break
+	if v[0] == '\r' && v[1] == '\n' {
+		return true
+	}
+
+	if isValidHexByte(v[0]) && isValidHexByte(v[1]) {
+		return true
+	}
+
+	return false
 }

--- a/quotedprint.go
+++ b/quotedprint.go
@@ -38,10 +38,8 @@ func (qp *qpCleaner) Read(dest []byte) (n int, err error) {
 		case b == '=':
 			// pass valid hex bytes through
 			hexBytes, err := qp.in.Peek(2)
-			if err != nil {
-				if err != io.EOF {
-					return 0, err
-				}
+			if err != nil && err != io.EOF {
+				return 0, err
 			}
 			if isValidHexBytes(hexBytes) {
 				dest[n] = b

--- a/testdata/parts/quoted-printable-invalid.raw
+++ b/testdata/parts/quoted-printable-invalid.raw
@@ -2,6 +2,8 @@ Content-Type: text/plain; charset="utf-8"
 Content-Transfer-Encoding: quoted-printable
 Content-Disposition: inline
 
+https://www.amazon.ca/gp/product/B002M8EEW8/ref=od_aui_detailpages00?ie=UTF8&psc=1
+
 Stuffs’s Weekly Summary
 Sunday, January 15th – Saturday, January 21st
 


### PR DESCRIPTION
I ran into an issue today with the sanitizer. Another email from slack came through but this time it contained a url with query parameters. The '=' passes through to qp reader and fails. Here is my first pass. Thoughts?
