### PR TITLE
Missing SMTP header on binary only email.

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -190,6 +190,9 @@ func parseBinaryOnlyBody(root *Part, e *Envelope) error {
 	// Add our part to the appropriate section of the Envelope
 	e.Root = NewPart(nil, mediatype)
 
+	// Add header from binary only part
+	e.Root.Header = root.Header
+
 	if root.Disposition == cdInline {
 		e.Inlines = append(e.Inlines, root)
 	} else {

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -783,6 +783,10 @@ func TestAttachmentOnly(t *testing.T) {
 				t.Errorf("Content should be PNG image, got: %v", allBytes)
 			}
 		}
+		// Check, if root header is set
+		if len(e.Root.Header) < 1 {
+			t.Errorf("No root header defined, but must be set from binary only part.")
+		}
 	}
 }
 


### PR DESCRIPTION
When a binary only e.Root is created, the original header was not added to e.Root.Header.