### PR TITLE
Don't use CharsetReader when Part is attachement

### DIFF
--- a/part.go
+++ b/part.go
@@ -103,7 +103,7 @@ func (p *Part) buildContentReaders(r io.Reader) error {
 	}
 	p.decodedReader = contentReader
 
-	if valid {
+	if valid && !isAttachment(p.Header){
 		// decodedReader is good; build character set conversion reader
 		if p.Charset != "" {
 			if reader, err := newCharsetReader(p.Charset, contentReader); err == nil {


### PR DESCRIPTION
For this [issue](https://github.com/jhillyerd/enmime/issues/42)