### PR TITLE
Feature/epilogue

### DIFF
--- a/envelope_test.go
+++ b/envelope_test.go
@@ -1021,7 +1021,7 @@ func TestBinaryOnlyBodyHeaders(t *testing.T) {
 	}
 }
 
-func TestEnvelopEpilogue(t *testing.T) {
+func TestEnvelopeEpilogue(t *testing.T) {
 
 	msg := openTestData("mail", "epilogue-sample.raw")
 	e, err := ReadEnvelope(msg)

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -1024,12 +1024,13 @@ func TestBinaryOnlyBodyHeaders(t *testing.T) {
 func TestEnvelopeEpilogue(t *testing.T) {
 	msg := openTestData("mail", "epilogue-sample.raw")
 	e, err := ReadEnvelope(msg)
-
 	if err != nil {
 		t.Fatal("Failed to parse MIME:", err)
 	}
 
-	if e.Root.Epilogue.Len() == 0 {
-		t.Error("Epilogue extraction not working, len was 0")
+	got := string(e.Root.Epilogue)
+	want := "Potentially malicious content\n"
+	if got != want {
+		t.Errorf("Epilogue == %q, want: %q", got, want)
 	}
 }

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -1022,7 +1022,6 @@ func TestBinaryOnlyBodyHeaders(t *testing.T) {
 }
 
 func TestEnvelopeEpilogue(t *testing.T) {
-
 	msg := openTestData("mail", "epilogue-sample.raw")
 	e, err := ReadEnvelope(msg)
 

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -1030,7 +1030,7 @@ func TestEnvelopEpilogue(t *testing.T) {
 		t.Fatal("Failed to parse MIME:", err)
 	}
 
-	if e.Root.Epiloge.Len() == 0 {
+	if e.Root.Epilogue.Len() == 0 {
 		t.Errorf("Epilogue extraction not working")
 	}
 }

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -1030,6 +1030,6 @@ func TestEnvelopeEpilogue(t *testing.T) {
 	}
 
 	if e.Root.Epilogue.Len() == 0 {
-		t.Errorf("Epilogue extraction not working")
+		t.Error("Epilogue extraction not working, len was 0")
 	}
 }

--- a/part.go
+++ b/part.go
@@ -29,7 +29,7 @@ type Part struct {
 	Errors      []Error              // Errors encountered while parsing this part
 	PartID      string               // The ID representing the part's exact position within the MIME Part Tree
 	Utf8Reader  io.Reader            // The decoded content converted to UTF-8
-	Epiloge     bytes.Buffer         // This is the epiloge of the email.
+	Epilogue    bytes.Buffer         // This is the epilogue of the email.
 
 	boundary      string    // Boundary marker used within this part
 	rawReader     io.Reader // The raw Part content, no decoding or charset conversion
@@ -167,12 +167,12 @@ func ReadParts(r io.Reader) (*Part, error) {
 		// Content is multipart, parse it
 		boundary := params[hpBoundary]
 		root.boundary = boundary
-		// Get epiloge
-		emailContent, epiloge, err := splitEpilogue(br, boundary)
+		// Get Epilogue
+		emailContent, epilogue, err := splitEpilogue(br, boundary)
 		if err != nil {
 			return nil, err
 		}
-		root.Epiloge = epiloge
+		root.Epilogue = epilogue
 		err = parseParts(root, bufio.NewReader(&emailContent), boundary)
 		if err != nil {
 			return nil, err

--- a/part.go
+++ b/part.go
@@ -191,10 +191,10 @@ func splitEpilogue(r *bufio.Reader, boundary string) (bytes.Buffer, bytes.Buffer
 	var emailBody bytes.Buffer
 	var epilogue bytes.Buffer
 	closingBoundary := "--" + boundary + "--"
-	tp := bufio.NewReader(r)
+	emailBodyReader := bufio.NewReader(r)
 	var eofReached = false
 	for !eofReached {
-		emailLine, err := tp.ReadBytes('\n')
+		emailLine, err := emailBodyReader.ReadBytes('\n')
 		if err != nil {
 			if err != io.EOF {
 				return emailBody, epilogue, err

--- a/part.go
+++ b/part.go
@@ -29,7 +29,7 @@ type Part struct {
 	Errors      []Error              // Errors encountered while parsing this part
 	PartID      string               // The ID representing the part's exact position within the MIME Part Tree
 	Utf8Reader  io.Reader            // The decoded content converted to UTF-8
-	Epilogue    bytes.Buffer         // This is the epilogue of the email.
+	Epilogue    bytes.Buffer         // Content following the closing boundary marker
 
 	boundary      string    // Boundary marker used within this part
 	rawReader     io.Reader // The raw Part content, no decoding or charset conversion
@@ -173,7 +173,7 @@ func ReadParts(r io.Reader) (*Part, error) {
 			return nil, err
 		}
 		root.Epilogue = epilogue
-		err = parseParts(root, bufio.NewReader(&emailContent), boundary)
+		err = parseParts(root, bufio.NewReader(&emailContent))
 		if err != nil {
 			return nil, err
 		}
@@ -187,7 +187,7 @@ func ReadParts(r io.Reader) (*Part, error) {
 	return root, nil
 }
 
-func splitEpilogue(r *bufio.Reader, boundary string) (bytes.Buffer, bytes.Buffer, error) {
+func splitEpilogue(r io.Reader, boundary string) (bytes.Buffer, bytes.Buffer, error) {
 	var emailBody bytes.Buffer
 	var epilogue bytes.Buffer
 	closingBoundary := "--" + boundary + "--"

--- a/part_test.go
+++ b/part_test.go
@@ -1,8 +1,6 @@
 package enmime
 
 import (
-	"bufio"
-	"bytes"
 	"testing"
 )
 
@@ -760,80 +758,5 @@ func TestBadBoundaryTerm(t *testing.T) {
 	want = "An HTML section"
 	if ok, err := contentContainsString(p, want); !ok {
 		t.Error("Part", err)
-	}
-}
-
-func TestSplitEpilogue(t *testing.T) {
-	emailBody := bytes.NewBuffer([]byte(`--Enmime-Test-100
-Content-Transfer-Encoding: 7bit
-Content-Type: text/plain; charset=us-ascii
-
-A text section
---Enmime-Test-100
-Content-Transfer-Encoding: base64
-Content-Type: text/html; name="test.html"
-Content-Disposition: attachment; filename=test.html
-
-PGh0bWw+Cg==
-
---Enmime-Test-100-->
-PGh0bWw+Cg==`))
-	wantBody := []byte(`--Enmime-Test-100
-Content-Transfer-Encoding: 7bit
-Content-Type: text/plain; charset=us-ascii
-
-A text section
---Enmime-Test-100
-Content-Transfer-Encoding: base64
-Content-Type: text/html; name="test.html"
-Content-Disposition: attachment; filename=test.html
-
-PGh0bWw+Cg==
-
---Enmime-Test-100-->
-`)
-	wantEpilogue := []byte(`PGh0bWw+Cg==`)
-
-	body, epilogue, err := splitEpilogue(bufio.NewReader(emailBody), "Enmime-Test-100")
-	if err != nil {
-		t.Error("Error getting epilogue", err)
-	}
-	if !bytes.Equal(body.Bytes(), wantBody) {
-		t.Errorf("len(body) == %v, want %v", body.Len(), len(wantBody))
-	}
-	if !bytes.Equal(epilogue.Bytes(), wantEpilogue) {
-		t.Errorf("epilogue == %v, want: %v", epilogue.Bytes(), wantEpilogue)
-	}
-}
-
-func BenchmarkSplitEpilogue(b *testing.B) {
-	// Build longish test MIME data
-	buf := new(bytes.Buffer)
-	buf.WriteString(`--Enmime-Test-100
-Content-Transfer-Encoding: 7bit
-Content-Type: text/plain; charset=us-ascii
-
-`)
-	for i := 0; i < 1000; i++ {
-		buf.WriteString("the quick brown fox jumped over the lazy dog and achieved enlightenment\n")
-	}
-	buf.WriteString(`--Enmime-Test-100-->
-PGh0bWw+Cg==`)
-	bufBytes := buf.Bytes()
-	b.SetBytes(int64(buf.Len()))
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		r := bufio.NewReader(bytes.NewReader(bufBytes))
-		body, epilogue, err := splitEpilogue(r, "Enmime-Test-100")
-		if err != nil {
-			b.Fatal(err)
-		}
-		if body.Len() == 0 {
-			b.Fatal("body was empty")
-		}
-		if epilogue.Len() == 0 {
-			b.Fatal("epilogue was empty")
-		}
 	}
 }

--- a/part_test.go
+++ b/part_test.go
@@ -764,7 +764,6 @@ func TestBadBoundaryTerm(t *testing.T) {
 }
 
 func TestSplitEpiloge(t *testing.T) {
-
 	emailBody := bytes.NewBuffer([]byte(`--Enmime-Test-100
 Content-Transfer-Encoding: 7bit
 Content-Type: text/plain; charset=us-ascii

--- a/part_test.go
+++ b/part_test.go
@@ -778,8 +778,7 @@ PGh0bWw+Cg==
 
 --Enmime-Test-100-->
 PGh0bWw+Cg==`))
-	boundary := "Enmime-Test-100"
-	expectedBody := bytes.NewBuffer([]byte(`--Enmime-Test-100
+	wantBody := []byte(`--Enmime-Test-100
 Content-Transfer-Encoding: 7bit
 Content-Type: text/plain; charset=us-ascii
 
@@ -792,17 +791,17 @@ Content-Disposition: attachment; filename=test.html
 PGh0bWw+Cg==
 
 --Enmime-Test-100-->
-`))
-	expectedEpilogue := bytes.NewBuffer([]byte(`PGh0bWw+Cg==`))
+`)
+	wantEpilogue := []byte(`PGh0bWw+Cg==`)
 
-	body, epilogue, err := splitEpilogue(bufio.NewReader(emailBody), boundary)
+	body, epilogue, err := splitEpilogue(bufio.NewReader(emailBody), "Enmime-Test-100")
 	if err != nil {
 		t.Error("Error getting epilogue", err)
 	}
-	if !bytes.Equal(body.Bytes(), expectedBody.Bytes()) {
+	if !bytes.Equal(body.Bytes(), wantBody) {
 		t.Error("Error mismatch body")
 	}
-	if !bytes.Equal(epilogue.Bytes(), expectedEpilogue.Bytes()) {
-		t.Error("Error mismatch epilogue")
+	if !bytes.Equal(epilogue.Bytes(), wantEpilogue) {
+		t.Errorf("epilogue == %v, want: %v", epilogue.Bytes(), wantEpilogue)
 	}
 }

--- a/part_test.go
+++ b/part_test.go
@@ -1,6 +1,8 @@
 package enmime
 
 import (
+	"bufio"
+	"bytes"
 	"testing"
 )
 
@@ -758,5 +760,50 @@ func TestBadBoundaryTerm(t *testing.T) {
 	want = "An HTML section"
 	if ok, err := contentContainsString(p, want); !ok {
 		t.Error("Part", err)
+	}
+}
+
+func TestSplitEpiloge(t *testing.T) {
+
+	emailBody := bytes.NewBuffer([]byte(`--Enmime-Test-100
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain; charset=us-ascii
+
+A text section
+--Enmime-Test-100
+Content-Transfer-Encoding: base64
+Content-Type: text/html; name="test.html"
+Content-Disposition: attachment; filename=test.html
+
+PGh0bWw+Cg==
+
+--Enmime-Test-100-->
+PGh0bWw+Cg==`))
+	boundary := "Enmime-Test-100"
+	expectedBody := bytes.NewBuffer([]byte(`--Enmime-Test-100
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain; charset=us-ascii
+
+A text section
+--Enmime-Test-100
+Content-Transfer-Encoding: base64
+Content-Type: text/html; name="test.html"
+Content-Disposition: attachment; filename=test.html
+
+PGh0bWw+Cg==
+
+--Enmime-Test-100-->
+`))
+	expectedEpilogue := bytes.NewBuffer([]byte(`PGh0bWw+Cg==`))
+
+	body, epilogue, err := splitEpilogue(bufio.NewReader(emailBody), boundary)
+	if err != nil {
+		t.Error("Error getting epilogue", err)
+	}
+	if !bytes.Equal(body.Bytes(), expectedBody.Bytes()) {
+		t.Error("Error mismatch body")
+	}
+	if !bytes.Equal(epilogue.Bytes(), expectedEpilogue.Bytes()) {
+		t.Error("Error mismatch epilogue")
 	}
 }

--- a/testdata/mail/epilogue-sample.raw
+++ b/testdata/mail/epilogue-sample.raw
@@ -19,4 +19,4 @@ Content-Disposition: attachment; filename=test.html
 PGh0bWw+Cg==
 
 --Enmime-Test-100-->
-PGh0bWw+Cg==
+Potentially malicious content


### PR DESCRIPTION
Rebase & cherry pick of @pedrinimm contributed PR #41 for issue #32:

Epilogues are now used by spammers or attackers to insert malicious content into emails, this content comes in the form of other mime parts, these come right after the closing boundary of an email.