### PR TITLE
Missing Boundary on all Mime Parts

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -57,6 +57,24 @@ func (e *Envelope) AddressList(key string) ([]*mail.Address, error) {
 	return ret, nil
 }
 
+// DuplicateEnvelope returns a duplicate of the current Envelope
+func (e *Envelope) DuplicateEnvelope() *Envelope {
+	if e == nil {
+		return nil
+	}
+	newEnvelope := &Envelope{
+		e.Text,
+		e.HTML,
+		e.Root.DuplicatePart(),
+		e.Attachments,
+		e.Inlines,
+		e.OtherParts,
+		e.Errors,
+		e.header,
+	}
+	return newEnvelope
+}
+
 // ReadEnvelope is a wrapper around ReadParts and EnvelopeFromPart.  It parses the content of the
 // provided reader into an Envelope, downconverting HTML to plain text if needed, and sorting the
 // attachments, inlines and other parts into their respective slices. Errors are collected from all

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -860,3 +860,13 @@ func TestEnvelopeEpilogue(t *testing.T) {
 		t.Errorf("Epilogue == %q, want: %q", got, want)
 	}
 }
+
+func TestDuplicateEnvelope(t *testing.T) {
+	msg := test.OpenTestData("mail", "epilogue-sample.raw")
+	e, err := enmime.ReadEnvelope(msg)
+	if err != nil {
+		t.Fatal("Failed to parse MIME:", err)
+	}
+	duplicateEnvelope := e.DuplicateEnvelope()
+	test.CompareEnvelope(t, duplicateEnvelope, e)
+}

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -129,3 +129,53 @@ func ContentEqualsBytes(t *testing.T, b []byte, want []byte) {
 		t.Errorf("content:\n%v, want:\n%v", b, want)
 	}
 }
+
+// CompareEnvelope test helper compares the attributes of two envelopes, returning true if they are equal.
+// t.Errorf() will be called for each field that is not equal.  The presence of child and siblings
+// will be checked, but not the attributes of them.  Unexported fields are
+// ignored.
+func CompareEnvelope(t *testing.T, got *enmime.Envelope, want *enmime.Envelope) (equal bool) {
+	t.Helper()
+	if got == nil && want != nil {
+		t.Error("Envelope == nil, want not nil")
+		return
+	}
+	if got != nil && want == nil {
+		t.Error("Envelope != nil, want nil")
+		return
+	}
+	equal = true
+	if got == nil && want == nil {
+		return
+	}
+	if !ComparePart(t, got.Root, want.Root) {
+		equal = false
+		t.Error("Envelope.Root mismatch between envelopes")
+	}
+	if got.Text != want.Text {
+		equal = false
+		t.Errorf("Envelope.Text == %q, want: %q", got.Text, want.Text)
+	}
+	if got.HTML != want.HTML {
+		equal = false
+		t.Errorf("Envelope.HTML == %q, want: %q", got.HTML, want.HTML)
+	}
+	if len(got.Attachments) != len(want.Attachments) {
+		equal = false
+		t.Errorf("Envelope.Attachments has %q elements, want: %q", len(got.Attachments), len(want.Attachments))
+	}
+	if len(got.Inlines) != len(want.Inlines) {
+		equal = false
+		t.Errorf("Envelope.Inlines has %q elements, want: %q", len(got.Inlines), len(want.Inlines))
+	}
+	if len(got.OtherParts) != len(want.OtherParts) {
+		equal = false
+		t.Errorf("Envelope.OtherParts has %q elements, want: %q", len(got.OtherParts), len(want.OtherParts))
+	}
+	if len(got.Errors) != len(want.Errors) {
+		equal = false
+		t.Errorf("Envelope.Errors has %q elements, want: %q", len(got.Errors), len(want.Errors))
+	}
+
+	return
+}

--- a/part_test.go
+++ b/part_test.go
@@ -724,3 +724,19 @@ func TestBadBoundaryTerm(t *testing.T) {
 	want = "An HTML section"
 	test.ContentContainsString(t, p.Content, want)
 }
+
+func TestDuplicatePart(t *testing.T) {
+	r := test.OpenTestData("parts", "multiother.raw")
+	p, err := enmime.ReadParts(r)
+
+	// Examine root
+	if err != nil {
+		t.Fatal("Unexpected parse error:", err)
+	}
+	if p == nil {
+		t.Fatal("Root node should not be nil")
+	}
+
+	duplicatePart := p.DuplicatePart()
+	test.ComparePart(t, duplicatePart, p)
+}


### PR DESCRIPTION
Currently Parts insider envelope do not contain their boundary.

This is an issue when you have a multipart/alternative email inside a multipart/mixed. Because the if you want to retrieve the boundary of the html part inside the multipart/alternative you cant because the "parent" of this parts is its sibling txt. This one has an empty boundary. 

IMHO every mime part should be aware of its own boundary. 

This is added on part.go line 336

In addition I added some duplication functions just because they are useful when working with multiple copies of the same envelope. 