### PR TITLE
fix part cloning, needs reference to parent in recursion

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -66,7 +66,7 @@ func (e *Envelope) Clone() *Envelope {
 	newEnvelope := &Envelope{
 		e.Text,
 		e.HTML,
-		e.Root.Clone(),
+		e.Root.Clone(nil),
 		e.Attachments,
 		e.Inlines,
 		e.OtherParts,

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -862,7 +862,7 @@ func TestEnvelopeEpilogue(t *testing.T) {
 }
 
 func TestCloneEnvelope(t *testing.T) {
-	msg := test.OpenTestData("mail", "epilogue-sample.raw")
+	msg := test.OpenTestData("mail", "other-multi-related.raw")
 	e, err := enmime.ReadEnvelope(msg)
 	if err != nil {
 		t.Fatal("Failed to parse MIME:", err)

--- a/part.go
+++ b/part.go
@@ -230,36 +230,31 @@ func (p *Part) buildContentReaders(r io.Reader) error {
 }
 
 // Clone returns a clone of the current Part
-func (p *Part) Clone() *Part {
+func (p *Part) Clone(parent *Part) *Part {
 	if p == nil {
 		return nil
 	}
 
 	newPart := &Part{
-		p.PartID,
-		p.Header,
-		nil,
-		p.FirstChild.Clone(),
-		p.NextSibling.Clone(),
-		p.Boundary,
-		p.ContentID,
-		p.ContentType,
-		p.Disposition,
-		p.FileName,
-		p.Charset,
-		p.Errors,
-		p.Content,
-		p.Epilogue,
-		p.Utf8Reader,
-		p.rawReader,
-		p.decodedReader,
+		PartID:        p.PartID,
+		Header:        p.Header,
+		Parent:        parent,
+		Boundary:      p.Boundary,
+		ContentID:     p.ContentID,
+		ContentType:   p.ContentType,
+		Disposition:   p.Disposition,
+		FileName:      p.FileName,
+		Charset:       p.Charset,
+		Errors:        p.Errors,
+		Content:       p.Content,
+		Epilogue:      p.Epilogue,
+		Utf8Reader:    p.Utf8Reader,
+		rawReader:     p.rawReader,
+		decodedReader: p.decodedReader,
 	}
-	if newPart.FirstChild != nil {
-		newPart.FirstChild.Parent = newPart
-	}
-	if newPart.NextSibling != nil {
-		newPart.NextSibling.Parent = newPart
-	}
+	newPart.FirstChild = p.FirstChild.Clone(newPart)
+	newPart.NextSibling = p.NextSibling.Clone(parent)
+
 	return newPart
 }
 

--- a/part_test.go
+++ b/part_test.go
@@ -737,6 +737,6 @@ func TestClonePart(t *testing.T) {
 		t.Fatal("Root node should not be nil")
 	}
 
-	clone := p.Clone()
+	clone := p.Clone(nil)
 	test.ComparePart(t, clone, p)
 }


### PR DESCRIPTION
I found an issue with yesterday's PR #66. By providing the parent part in the part.Clone() loop, references to newPart.Parent can be updated on the fly.