### PR TITLE
Fix parseBinaryOnlyBody by adding Content

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -207,8 +207,9 @@ func parseBinaryOnlyBody(root *Part, e *Envelope) error {
 	// Add our part to the appropriate section of the Envelope
 	e.Root = NewPart(nil, mediatype)
 
-	// Add header from binary only part
+	// Add header and content from binary only part
 	e.Root.Header = root.Header
+	e.Root.Content = root.Content
 
 	if root.Disposition == cdInline {
 		e.Inlines = append(e.Inlines, root)

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -654,6 +654,10 @@ func TestAttachmentOnly(t *testing.T) {
 		if len(e.Root.Header) < 1 {
 			t.Errorf("No root header defined, but must be set from binary only part.")
 		}
+		// Check, that the root part has content
+		if len(e.Root.Content) == 0 {
+			t.Errorf("Root part of envelope has no content.")
+		}
 	}
 }
 


### PR DESCRIPTION
Currently, the `Content` of a BinaryOnlyMail is empty. It is possible to access the content with `env.Inlines[0].Content`, but this does not work in any case.

In my use case, I save all images from incoming messages. I do this with `DepthMatchAll()`. It returns a list of `Part`-objects. But in a BinaryOnlyMail there is no link between the `Part` and `env.Inlines[0]`. So without this patch, I see no way to access the content.