### PR TITLE
Add Envelope.GetHeaders()

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -23,6 +23,18 @@ type Envelope struct {
 	header      *textproto.MIMEHeader // Header from original message
 }
 
+// GetHeaderKeys returns a list of header keys seen in this message. Get
+// individual headers with `GetHeader(name)`
+func (e *Envelope) GetHeaderKeys() (headers []string) {
+	if e.header == nil {
+		return
+	}
+	for key := range *e.header {
+		headers = append(headers, key)
+	}
+	return headers
+}
+
 // GetHeader processes the specified header for RFC 2047 encoded words and returns the result as a
 // UTF-8 string
 func (e *Envelope) GetHeader(name string) string {

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -2,6 +2,7 @@ package enmime_test
 
 import (
 	"bytes"
+	"sort"
 	"strings"
 	"testing"
 
@@ -493,6 +494,40 @@ func TestEnvelopeGetHeader(t *testing.T) {
 	if got != want {
 		t.Errorf("Subject was: %q, want: %q", got, want)
 	}
+}
+
+func TestEnvelopeGetHeaderKeys(t *testing.T) {
+	// Test empty header
+	e := &enmime.Envelope{}
+	got := e.GetHeaderKeys()
+	if got != nil {
+		t.Errorf("Headers was: %q, want: nil", got)
+	}
+
+	// Even non-MIME messages should support encoded-words in headers
+	// Also, encoded addresses should be suppored
+	r := test.OpenTestData("mail", "qp-ascii-header.raw")
+	e, err := enmime.ReadEnvelope(r)
+	if err != nil {
+		t.Fatal("Failed to parse non-MIME:", err)
+	}
+
+	want := []string{"Date", "From", "Subject", "To", "X-Mailer"}
+	got = e.GetHeaderKeys()
+	sort.Sort(sort.StringSlice(got))
+	test.DiffStrings(t, got, want)
+
+	// Test UTF-8 subject line
+	r = test.OpenTestData("mail", "qp-utf8-header.raw")
+	e, err = enmime.ReadEnvelope(r)
+	if err != nil {
+		t.Fatal("Failed to parse MIME:", err)
+	}
+
+	want = []string{"Content-Type", "Date", "From", "Message-Id", "Mime-Version", "Sender", "Subject", "To", "User-Agent"}
+	got = e.GetHeaderKeys()
+	sort.Sort(sort.StringSlice(got))
+	test.DiffStrings(t, got, want)
 }
 
 func TestEnvelopeAddressList(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/smtp"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/jhillyerd/enmime"
@@ -177,4 +178,40 @@ hello again!
 	//
 	// Envelope errors:
 	// [W] Malformed Header: Continued line "filename=hi.txt" was not indented
+}
+
+func ExampleEnvelope_GetHeaderKeys() {
+	// Open a sample message file.
+	r, err := os.Open("testdata/mail/qp-utf8-header.raw")
+	if err != nil {
+		fmt.Print(err)
+		return
+	}
+
+	// Parse message with enmime.
+	env, err := enmime.ReadEnvelope(r)
+	if err != nil {
+		fmt.Print(err)
+		return
+	}
+
+	// A list of headers is retrieved via Envelope.GetHeaderKeys().
+	headers := env.GetHeaderKeys()
+	sort.Sort(sort.StringSlice(headers))
+
+	// Print each header, key and value.
+	for _, header := range headers {
+		fmt.Printf("%s: %v\n", header, env.GetHeader(header))
+	}
+
+	// Output:
+	// Content-Type: multipart/alternative; boundary="------------020203040006070307010003"
+	// Date: Fri, 19 Oct 2012 12:22:49 -0700
+	// From: James Hillyerd <jamehi03@jamehi03lx.noa.com>, André Pirard <PIRARD@vm1.ulg.ac.be>
+	// Message-Id: <5081A889.3020108@jamehi03lx.noa.com>
+	// Mime-Version: 1.0
+	// Sender: André Pirard <PIRARD@vm1.ulg.ac.be>
+	// Subject: MIME UTF8 Test ¢ More Text
+	// To: Mirosław Marczak <marczak@inbucket.com>
+	// User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0) Gecko/20121010 Thunderbird/16.0.1
 }


### PR DESCRIPTION
This provides (roundabout) access to the `textproto.MIMEHeader` field of the `Envelope` struct. It's handy for various situations, like telling if there are optional DKIM or SPF headers.