### PR TITLE
Bugfix HTML charset.

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -162,6 +162,17 @@ func parseTextOnlyBody(root *Part, e *Envelope) error {
 					root.addWarning(ErrorCharsetConversion, err.Error())
 				}
 			}
+			// Converted from charset in HTML
+			return nil
+		}
+
+		// Use charset found in header
+		if convHTML, err := coding.ConvertToUTF8String(charset, root.Content); err == nil {
+			// Successful conversion
+			e.HTML = convHTML
+		} else {
+			// Conversion failed
+			root.addWarning(ErrorCharsetConversion, err.Error())
 		}
 	} else {
 		e.Text = string(root.Content)

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -458,6 +458,22 @@ func TestParseNestedHeaders(t *testing.T) {
 	}
 }
 
+func TestParseHTMLOnlyCharsetInHeaderOnly(t *testing.T) {
+	msg := test.OpenTestData("mail", "non-mime-html-charset-header-only.raw")
+	e, err := enmime.ReadEnvelope(msg)
+	if err != nil {
+		t.Fatal("Failed to parse non-MIME:", err)
+	}
+
+	if !strings.ContainsRune(e.HTML, 0xfc) {
+		t.Error("HTML body should contained German ü")
+	}
+
+	if !strings.Contains(e.HTML, "Müller") {
+		t.Error("HTML body should contained 'Müller'")
+	}
+}
+
 func TestEnvelopeGetHeader(t *testing.T) {
 	// Test empty header
 	e := &enmime.Envelope{}

--- a/testdata/mail/non-mime-html-charset-header-only.raw
+++ b/testdata/mail/non-mime-html-charset-header-only.raw
@@ -1,0 +1,17 @@
+From: alice@intern.com
+To: bob@extern.com
+Message-ID: <1913211271.2.1528358425638@zeus>
+Subject: Test
+MIME-Version: 1.0
+Content-Type: text/html;charset="iso-8859-1"
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+    Test M=FCller
+  </body>
+</html>


### PR DESCRIPTION
A chaset maybe set in header of HTML only emails, but not set in HTML
part. If a charset is set on HTML only email, use it to convert
content.

If Content-Type: text/html;charset="iso-8859-1" is set in mail header, but HTML body does not contain meta Content-Type, the body is not converted to utf-8.