### PR TITLE
Fix for multipart/mixed with inline disposition.

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -266,7 +266,7 @@ func parseMultiPartBody(root *Part, e *Envelope) error {
 
 	// Locate inlines
 	e.Inlines = root.BreadthMatchAll(func(p *Part) bool {
-		return p.Disposition == cdInline
+		return p.Disposition == cdInline && !strings.HasPrefix(p.ContentType, ctMultipartPrefix)
 	})
 
 	// Locate others parts not considered in attachments or inlines

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -492,6 +492,40 @@ func TestParseHTMLOnlyInline(t *testing.T) {
 	}
 }
 
+func TestParseInlineMultipart(t *testing.T) {
+	msg := test.OpenTestData("mail", "inlinemultipart.raw")
+	e, err := enmime.ReadEnvelope(msg)
+	if err != nil {
+		t.Fatal("Failed to parse MIME:", err)
+	}
+
+	if len(e.Errors) != 0 {
+		t.Errorf("len(e.Errors) got: %v, want: 0", len(e.Errors))
+	}
+
+	want := "Simple text."
+	if !strings.Contains(e.Text, want) {
+		t.Errorf("Downconverted Text: %q should contain: %q", e.Text, want)
+	}
+
+	if len(e.Inlines) != 1 {
+		t.Error("Should have no inline, got:", len(e.Inlines))
+	}
+	if len(e.Attachments) != 1 {
+		t.Fatal("Should have one attachments, got:", len(e.Attachments))
+	}
+
+	want = "test.txt"
+	got := e.Inlines[0].FileName
+	if got != want {
+		t.Error("FileName got:", got, "want:", want)
+	}
+
+	if !bytes.HasPrefix(e.Inlines[0].Content, []byte("Text")) {
+		t.Error("Inline should have correct content")
+	}
+}
+
 func TestParseNestedHeaders(t *testing.T) {
 	msg := test.OpenTestData("mail", "html-mime-inline.raw")
 	e, err := enmime.ReadEnvelope(msg)

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -509,7 +509,7 @@ func TestParseInlineMultipart(t *testing.T) {
 	}
 
 	if len(e.Inlines) != 1 {
-		t.Error("Should have no inline, got:", len(e.Inlines))
+		t.Error("Should have one inline, got:", len(e.Inlines))
 	}
 	if len(e.Attachments) != 1 {
 		t.Fatal("Should have one attachments, got:", len(e.Attachments))

--- a/testdata/mail/inlinemultipart.raw
+++ b/testdata/mail/inlinemultipart.raw
@@ -1,0 +1,39 @@
+Subject: Test
+To: alice@intern
+From: bob@extern
+Content-Type: multipart/mixed;
+	boundary="0__=4EBB0828DFD318FF8f9e8a93df938690918c4EBB0828DFD318FF"
+Content-Disposition: inline
+MIME-Version: 1.0
+
+--0__=4EBB0828DFD318FF8f9e8a93df938690918c4EBB0828DFD318FF
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+
+Simple text.
+
+--0__=4EBB0828DFD318FF8f9e8a93df938690918c4EBB0828DFD318FF
+Content-Type: application/pdf; name="test.pdf"; name="test.pdf"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="test.pdf"
+
+JVBERi0xLjINCg0KNCAwIG9iag0KPDwNCi9FIDYxOTUNCi9IIFsgMTIxMSAxNDUgXQ0KL0wgNjUy
+MA0KL0xpbmVhcml6ZWQgMQ0KL04gMQ0KL08gNw0KL1QgNjM5MA0KPj4gICAgICAgICAgICAgICAg
+ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
+DQplbmRvYmoNCg0KeHJlZg0KNCA4DQowMDAwMDAwMDEyIDAwMDAwIG4NCjAwMDAwMDEwODggMDAw
+MDAgbg0KMDAwMDAwMTIxMSAwMDAwMCBuDQowMDAwMDAxMzU2IDAwMDAwIG4NCjAwMDAwMDE2MDcg
+MDAwMDAgbg0KMDAwMDAwMTcxNiAwMDAwMCBuDQowMDAwMDAxODI0IDAwMDAwIG4NCjAwMDAwMDQz
+MTkgMDAwMDAgbg0KdHJhaWxlcg0KPDwNCi9BQkNwZGYgODEwNw0KL0lEIFsgPDNENzc5REU2NjU0
+RDM4ODczMTYzODBBNTY3REY0MDhFPg0KPDc5OEQ0RjVGNkUyNzIzQjA1MTFCQzU0QzYwMTczRDI3
+PiBdDQovSW5mbyAzIDAgUg0KL1ByZXYgNjM4MA0KL1Jvb3QgNSAwIFINCi9TaXplIDEyDQovU291
+cmNlIChXZUpYRnh
+
+--0__=4EBB0828DFD318FF8f9e8a93df938690918c4EBB0828DFD318FF
+Content-Type: text/plain; name="test.txt"; name="test.txt"
+Content-Disposition: inline
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="test.txt"
+
+Text attachment.
+
+--0__=4EBB0828DFD318FF8f9e8a93df938690918c4EBB0828DFD318FF--


### PR DESCRIPTION
If mail header is

   Content-Type: multipart/mixed;...
   Content-Disposition: inline

the resulting Envelope has an additional inline attachment with zero
bytes and a content type multipart/mixed. Changed test, so that
inlines with "multipart/" as content type prefix are not added to
inlines slice.