### PR TITLE
detect charset of email parts

### DIFF
--- a/error.go
+++ b/error.go
@@ -19,6 +19,8 @@ const (
 	ErrorContentEncoding = "Content Encoding"
 	// ErrorPlainTextFromHTML name.
 	ErrorPlainTextFromHTML = "Plain Text from HTML"
+	// ErrorCharsetDeclaration name.
+	ErrorCharsetDeclaration = "Character Set Declaration Mismatch"
 )
 
 // Error describes an error encountered while parsing.

--- a/part.go
+++ b/part.go
@@ -2,6 +2,7 @@ package enmime
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gogs/chardet"
 	"github.com/jhillyerd/enmime/internal/coding"
 )
 
@@ -28,6 +30,7 @@ type Part struct {
 	Disposition string               // Content-Disposition header without parameters.
 	FileName    string               // The file-name from disposition or type header.
 	Charset     string               // The content charset encoding label.
+	OrigCharset string               // The original content charset encoding label in case a different charset was detected.
 	Errors      []Error              // Errors encountered while parsing this part.
 	Content     []byte               // Content after decoding, UTF-8 conversion if applicable.
 	Epilogue    []byte               // Epilogue contains data following the closing boundary marker.
@@ -166,24 +169,58 @@ func (p *Part) decodeContent(r io.Reader) error {
 	}
 	// Build charset decoding reader.
 	if validEncoding && !detectAttachmentHeader(p.Header) {
-		if p.Charset != "" {
-			if reader, err := coding.NewCharsetReader(p.Charset, contentReader); err == nil {
+		var reader io.Reader
+
+		// get charset detector
+		var cd *chardet.Detector
+		cd = chardet.NewTextDetector()
+		if p.ContentType == "text/html" {
+			cd = chardet.NewHtmlDetector()
+		}
+		// detect charset
+		buf, err := ioutil.ReadAll(contentReader)
+		if err != nil {
+			return err
+		}
+		cs, err := cd.DetectBest(buf)
+		if err != nil {
+			return err
+		}
+		contentReader = bytes.NewReader(buf) // restore contentReader
+
+		if cs != nil && cs.Confidence >= 85 { // read with detected charset if confidence is high
+			if p.Charset != "" && !strings.EqualFold(cs.Charset, p.Charset) {
+				p.addWarning(ErrorCharsetDeclaration, fmt.Sprintf("Part %s: declared charset '%s', detected '%s', confidence %d", p.PartID, p.Charset, cs.Charset, cs.Confidence))
+			}
+			reader, err = coding.NewCharsetReader(cs.Charset, contentReader)
+			if err == nil {
 				contentReader = reader
-			} else {
-				// Try to parse charset again here to see if we can salvage some badly formed ones
-				// like charset="charset=utf-8".
-				charsetp := strings.Split(p.Charset, "=")
-				if strings.ToLower(charsetp[0]) == "charset" && len(charsetp) > 1 {
-					p.Charset = charsetp[1]
-					if reader, err := coding.NewCharsetReader(p.Charset, contentReader); err == nil {
-						contentReader = reader
+				p.OrigCharset = p.Charset
+				p.Charset = cs.Charset
+			}
+
+		} else { // read declared charset otherwise
+			if p.Charset != "" {
+				reader, err = coding.NewCharsetReader(p.Charset, contentReader)
+				if err == nil {
+					contentReader = reader
+				} else {
+					// Try to parse charset again here to see if we can salvage some badly formed ones
+					// like charset="charset=utf-8".
+					charsetp := strings.Split(p.Charset, "=")
+					if strings.ToLower(charsetp[0]) == "charset" && len(charsetp) > 1 {
+						p.Charset = charsetp[1]
+						reader, err = coding.NewCharsetReader(p.Charset, contentReader)
+						if err == nil {
+							contentReader = reader
+						} else {
+							// Failed to get a conversion reader.
+							p.addWarning(ErrorCharsetConversion, err.Error())
+						}
 					} else {
 						// Failed to get a conversion reader.
 						p.addWarning(ErrorCharsetConversion, err.Error())
 					}
-				} else {
-					// Failed to get a conversion reader.
-					p.addWarning(ErrorCharsetConversion, err.Error())
 				}
 			}
 		}

--- a/part_test.go
+++ b/part_test.go
@@ -328,7 +328,7 @@ func TestMultiMixedParts(t *testing.T) {
 		Parent:      test.PartExists,
 		NextSibling: test.PartExists,
 		ContentType: "text/plain",
-		Charset:     "us-ascii",
+		Charset:     "ISO-8859-1",
 		PartID:      "1",
 	}
 	test.ComparePart(t, p, wantp)
@@ -341,7 +341,7 @@ func TestMultiMixedParts(t *testing.T) {
 	wantp = &enmime.Part{
 		Parent:      test.PartExists,
 		ContentType: "text/plain",
-		Charset:     "us-ascii",
+		Charset:     "ISO-8859-1",
 		PartID:      "2",
 	}
 	test.ComparePart(t, p, wantp)
@@ -379,7 +379,7 @@ func TestMultiOtherParts(t *testing.T) {
 		Parent:      test.PartExists,
 		NextSibling: test.PartExists,
 		ContentType: "text/plain",
-		Charset:     "us-ascii",
+		Charset:     "ISO-8859-1",
 		PartID:      "1",
 	}
 	test.ComparePart(t, p, wantp)
@@ -392,7 +392,7 @@ func TestMultiOtherParts(t *testing.T) {
 	wantp = &enmime.Part{
 		Parent:      test.PartExists,
 		ContentType: "text/plain",
-		Charset:     "us-ascii",
+		Charset:     "ISO-8859-1",
 		PartID:      "2",
 	}
 	test.ComparePart(t, p, wantp)
@@ -523,7 +523,7 @@ func TestPartSimilarBoundary(t *testing.T) {
 		Parent:      test.PartExists,
 		NextSibling: test.PartExists,
 		ContentType: "text/plain",
-		Charset:     "us-ascii",
+		Charset:     "ISO-8859-1",
 		PartID:      "1",
 	}
 	test.ComparePart(t, p, wantp)

--- a/testdata/mail/html-only-inline.raw
+++ b/testdata/mail/html-only-inline.raw
@@ -17,7 +17,7 @@ Content-Type: multipart/related;
 --Apple-Mail=_D2ABE25A-F0FE-404E-94EE-D98BD23448D5
 Content-Transfer-Encoding: 7bit
 Content-Type: text/html;
-	charset=us-ascii
+	charset=ISO-8859-1
 
 <html><head></head><body style="word-wrap: break-word; -webkit-nbsp-mode: space; -webkit-line-break: after-white-space; "><font class="Apple-style-span" face="'Comic Sans MS'">Test of HTML section</font><img height="16" width="16" apple-width="yes" apple-height="yes" id="4579722f-d53d-45d0-88bc-f8209a2ca569" src="cid:8B8481A2-25CA-4886-9B5A-8EB9115DD064@skynet"></body></html>
 --Apple-Mail=_D2ABE25A-F0FE-404E-94EE-D98BD23448D5

--- a/testdata/mail/non-mime-html.raw
+++ b/testdata/mail/non-mime-html.raw
@@ -3,12 +3,12 @@ To: greg@inbucket.com
 From: James Hillyerd <james@hillyerd.com>
 Subject: test Sun, 14 Oct 2012 16:09:01 -0700
 X-Mailer: swaks v20120320.0 jetmore.org/john/code/swaks/
-Content-Type: text/html; charset="UTF-8"
+Content-Type: text/html; charset="ISO-8859-1"
 
 <html>
   <head>
     <title>Document Title</title>
-    <meta charset="utf-8"/>
+    <meta charset="iso-8859-1"/>
     <style>
       strong {
         font-size: 110%;
@@ -25,4 +25,3 @@ Content-Type: text/html; charset="UTF-8"
     </p>
   </body>
 </html>
-


### PR DESCRIPTION
This implements issue #81. Let me know if you think the content should also be decoded with the original charset, such that users can choose which one they want to use.