### PR TITLE
Resolves an issue parsing a malformed Content-Type header

### DIFF
--- a/part.go
+++ b/part.go
@@ -114,6 +114,11 @@ func (p *Part) setupHeaders(r *bufio.Reader, defaultContentType string) error {
 	if err != nil {
 		return err
 	}
+	if mtype == "" && len(mparams) > 0 {
+		p.addWarning(
+			ErrorMissingContentType,
+			"Content-Type header has parameters but no content type")
+	}
 	p.ContentType = mtype
 	// Set disposition, filename, charset if available.
 	p.setupContentHeaders(mparams)

--- a/part_test.go
+++ b/part_test.go
@@ -740,3 +740,47 @@ func TestClonePart(t *testing.T) {
 	clone := p.Clone(nil)
 	test.ComparePart(t, clone, p)
 }
+
+func TestBarrenContentType(t *testing.T) {
+	r := test.OpenTestData("parts", "barren-content-type.raw")
+	p, err := enmime.ReadParts(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := ""
+	if p.ContentType != want {
+		t.Errorf("ContentType %q, want %q", p.ContentType, want)
+	}
+	want = ""
+	if p.FileName != want {
+		t.Errorf("FileName %q, want %q", p.FileName, want)
+	}
+	want = ""
+	if p.Charset != want {
+		t.Errorf("Charset %q, want %q", p.Charset, want)
+	}
+	want = "attachment"
+	if p.Disposition != want {
+		t.Errorf("Disposition %q, want %q", p.Disposition, want)
+	}
+	want = ""
+	if p.ContentID != want {
+		t.Errorf("ContentID %q, want %q", p.ContentID, want)
+	}
+	satisfied := false
+	for _, perr := range p.Errors {
+		if perr.Name == enmime.ErrorMissingContentType {
+			satisfied = true
+			if perr.Severe {
+				t.Errorf("Expected Severe to be false, got true for %q", perr.Name)
+			}
+		}
+	}
+	if !satisfied {
+		t.Errorf(
+			"Did not find expected error on part. Expected %q, but had: %v",
+			enmime.ErrorMissingContentType,
+			p.Errors)
+	}
+}

--- a/testdata/parts/barren-content-type.raw
+++ b/testdata/parts/barren-content-type.raw
@@ -1,0 +1,6 @@
+Content-Type: ;
+	name=""
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+	filename=""
+


### PR DESCRIPTION
An email was received with this Content-Type header:

```
Content-Type: ;
	name=""
```

This change makes it so this MIME part can be parsed successfully.