### PR TITLE
Handled malformed Content-Type params

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -9,7 +9,7 @@ import (
 func detectMultipartMessage(root *Part) bool {
 	// Parse top-level multipart
 	ctype := root.Header.Get(hnContentType)
-	mediatype, _, err := parseMediaType(ctype)
+	mediatype, _, _, err := parseMediaType(ctype)
 	if err != nil {
 		return false
 	}
@@ -29,13 +29,13 @@ func detectMultipartMessage(root *Part) bool {
 //  - Content-Disposition: inline; filename="frog.jpg"
 //  - Content-Type: attachment; filename="frog.jpg"
 func detectAttachmentHeader(header textproto.MIMEHeader) bool {
-	mediatype, params, _ := parseMediaType(header.Get(hnContentDisposition))
+	mediatype, params, _, _ := parseMediaType(header.Get(hnContentDisposition))
 	if strings.ToLower(mediatype) == cdAttachment ||
 		(strings.ToLower(mediatype) == cdInline && len(params) > 0) {
 		return true
 	}
 
-	mediatype, _, _ = parseMediaType(header.Get(hnContentType))
+	mediatype, _, _, _ = parseMediaType(header.Get(hnContentType))
 	return strings.ToLower(mediatype) == cdAttachment
 }
 
@@ -48,7 +48,7 @@ func detectTextHeader(header textproto.MIMEHeader, emptyContentTypeIsText bool) 
 		return true
 	}
 
-	mediatype, _, err := parseMediaType(ctype)
+	mediatype, _, _, err := parseMediaType(ctype)
 	if err != nil {
 		return false
 	}
@@ -72,7 +72,7 @@ func detectBinaryBody(root *Part) bool {
 		// 'text/plain' or 'text/html'.
 		// Example:
 		// Content-Type: application/pdf; name="doc.pdf"
-		mediatype, _, _ := parseMediaType(root.Header.Get(hnContentType))
+		mediatype, _, _, _ := parseMediaType(root.Header.Get(hnContentType))
 		mediatype = strings.ToLower(mediatype)
 		if mediatype != ctTextPlain && mediatype != ctTextHTML {
 			return true

--- a/detect_test.go
+++ b/detect_test.go
@@ -98,6 +98,16 @@ func TestDetectAttachmentHeader(t *testing.T) {
 				"Content-Disposition": []string{"inline"}},
 		},
 		{
+			want: false,
+			header: textproto.MIMEHeader{
+				"Content-Disposition": []string{"inline; broken"}},
+		},
+		{
+			want: true,
+			header: textproto.MIMEHeader{
+				"Content-Disposition": []string{"attachment; broken"}},
+		},
+		{
 			want: true,
 			header: textproto.MIMEHeader{
 				"Content-Disposition": []string{"inline; filename=\"frog.jpg\""}},

--- a/envelope.go
+++ b/envelope.go
@@ -226,7 +226,7 @@ func parseTextOnlyBody(root *Part, e *Envelope) error {
 	var charset string
 	var isHTML bool
 	if ctype := root.Header.Get(hnContentType); ctype != "" {
-		if mediatype, mparams, err := parseMediaType(ctype); err == nil {
+		if mediatype, mparams, _, err := parseMediaType(ctype); err == nil {
 			isHTML = (mediatype == ctTextHTML)
 			if mparams[hpCharset] != "" {
 				charset = mparams[hpCharset]
@@ -265,7 +265,7 @@ func parseTextOnlyBody(root *Part, e *Envelope) error {
 func parseMultiPartBody(root *Part, e *Envelope) error {
 	// Parse top-level multipart
 	ctype := root.Header.Get(hnContentType)
-	mediatype, params, err := parseMediaType(ctype)
+	mediatype, params, _, err := parseMediaType(ctype)
 	if err != nil {
 		return fmt.Errorf("Unable to parse media type: %v", err)
 	}

--- a/header_test.go
+++ b/header_test.go
@@ -181,6 +181,21 @@ func TestFixMangledMediaType(t *testing.T) {
 			sep:   " ",
 			want:  "one/two;name=\"file.two\"",
 		},
+		{
+			input: "; name=\"file.two\"",
+			sep:   ";",
+			want:  ctPlaceholder + "; name=\"file.two\"",
+		},
+		{
+			input: "one/two;iso-8859-1",
+			sep:   ";",
+			want:  "one/two;iso-8859-1=" + pvPlaceholder,
+		},
+		{
+			input: "one/two; name=\"file.two\"; iso-8859-1",
+			sep:   ";",
+			want:  "one/two; name=\"file.two\"; iso-8859-1=" + pvPlaceholder,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {

--- a/part.go
+++ b/part.go
@@ -110,7 +110,7 @@ func (p *Part) setupHeaders(r *bufio.Reader, defaultContentType string) error {
 		ctype = defaultContentType
 	}
 	// Parse Content-Type header.
-	mtype, mparams, err := parseMediaType(ctype)
+	mtype, mparams, minvalidParams, err := parseMediaType(ctype)
 	if err != nil {
 		return err
 	}
@@ -118,6 +118,12 @@ func (p *Part) setupHeaders(r *bufio.Reader, defaultContentType string) error {
 		p.addWarning(
 			ErrorMissingContentType,
 			"Content-Type header has parameters but no content type")
+	}
+	for i := range minvalidParams {
+		p.addWarning(
+			ErrorMalformedHeader,
+			"Content-Type header has malformed parameter %q",
+			minvalidParams[i])
 	}
 	p.ContentType = mtype
 	// Set disposition, filename, charset if available.
@@ -131,7 +137,7 @@ func (p *Part) setupHeaders(r *bufio.Reader, defaultContentType string) error {
 // the disposition, filename, and charset fields.
 func (p *Part) setupContentHeaders(mediaParams map[string]string) {
 	// Determine content disposition, filename, character set.
-	disposition, dparams, err := parseMediaType(p.Header.Get(hnContentDisposition))
+	disposition, dparams, _, err := parseMediaType(p.Header.Get(hnContentDisposition))
 	if err == nil {
 		// Disposition is optional
 		p.Disposition = disposition

--- a/part_test.go
+++ b/part_test.go
@@ -784,3 +784,31 @@ func TestBarrenContentType(t *testing.T) {
 			p.Errors)
 	}
 }
+
+func TestMalformedContentTypeParams(t *testing.T) {
+	r := test.OpenTestData("parts", "malformed-content-type-params.raw")
+	p, err := enmime.ReadParts(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantp := &enmime.Part{
+		PartID:      "0",
+		ContentType: "text/html",
+	}
+	test.ComparePart(t, p, wantp)
+	satisfied := false
+	for _, perr := range p.Errors {
+		if perr.Name == enmime.ErrorMalformedHeader {
+			satisfied = true
+			if perr.Severe {
+				t.Errorf("Expected Severe to be false, got true for %q", perr.Name)
+			}
+		}
+	}
+	if !satisfied {
+		t.Errorf(
+			"Did not find expected error on part. Expected %q, but had: %v",
+			enmime.ErrorMalformedHeader,
+			p.Errors)
+	}
+}

--- a/testdata/parts/malformed-content-type-params.raw
+++ b/testdata/parts/malformed-content-type-params.raw
@@ -1,0 +1,2 @@
+Content-Type: text/html;iso-8859-1
+


### PR DESCRIPTION
Handled an issue when a content-type header like this is encountered:

`Content-Type: text/html;iso-8859-1`