### PR TITLE
 Fix content-type params with unquoted specials per RFC 2045, section 5.1

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -207,6 +207,105 @@ func TestFixMangledMediaType(t *testing.T) {
 	}
 }
 
+func TestFixUnquotedSpecials(t *testing.T) {
+	testCases := []struct {
+		input, want string
+	}{
+		{
+			input: "",
+			want:  "",
+		},
+		{
+			input: "application/octet-stream",
+			want:  "application/octet-stream",
+		},
+		{
+			input: "application/octet-stream;",
+			want:  "application/octet-stream;",
+		},
+		{
+			input: "application/octet-stream; param1=\"value1\"",
+			want:  "application/octet-stream; param1=\"value1\"",
+		},
+		{
+			input: "application/octet-stream; param1=\"value1\"\\",
+			want:  "application/octet-stream; param1=\"value1\"\\",
+		},
+		{
+			input: "application/octet-stream; param1=value1",
+			want:  "application/octet-stream; param1=value1",
+		},
+		{
+			input: "application/octet-stream; param1=value1\\",
+			want:  "application/octet-stream; param1=value1",
+		},
+		{
+			input: "application/octet-stream; param1=value1\\\"",
+			want:  "application/octet-stream; param1=\"value1\\\"\"",
+		},
+		{
+			input: "application/octet-stream; param1=value\"1\"",
+			want:  "application/octet-stream; param1=\"value\\\"1\\\"\"",
+		},
+		{
+			input: "application/octet-stream; param1=\"value\\\"1\\\"\"",
+			want:  "application/octet-stream; param1=\"value\\\"1\\\"\"",
+		},
+		{
+			input: "application/octet-stream; param1= value1",
+			want:  "application/octet-stream; param1= value1",
+		},
+		{
+			input: "application/octet-stream; param1=\tvalue1",
+			want:  "application/octet-stream; param1=\tvalue1",
+		},
+		{
+			input: "application/octet-stream; param1=\"value1;\"",
+			want:  "application/octet-stream; param1=\"value1;\"",
+		},
+		{
+			input: "application/octet-stream; param1=\"value 1\"",
+			want:  "application/octet-stream; param1=\"value 1\"",
+		},
+		{
+			input: "application/octet-stream; param1=\"value\t1\"",
+			want:  "application/octet-stream; param1=\"value\t1\"",
+		},
+		{
+			input: "application/octet-stream; param1=\"value(1).pdf\"",
+			want:  "application/octet-stream; param1=\"value(1).pdf\"",
+		},
+		{
+			input: "application/octet-stream; param1=value(1).pdf",
+			want:  "application/octet-stream; param1=\"value(1).pdf\"",
+		},
+		{
+			input: "application/octet-stream; param1=value(1).pdf; param2=value(2).pdf",
+			want:  "application/octet-stream; param1=\"value(1).pdf\"; param2=\"value(2).pdf\"",
+		},
+		{
+			input: "application/octet-stream; param1=value(1).pdf;\tparam2=value2.pdf;",
+			want:  "application/octet-stream; param1=\"value(1).pdf\";\tparam2=value2.pdf;",
+		},
+		{
+			input: "application/octet-stream; param1=value(1).pdf;param2=value2.pdf;",
+			want:  "application/octet-stream; param1=\"value(1).pdf\";param2=value2.pdf;",
+		},
+		{
+			input: "application/octet-stream; param1=value/1",
+			want:  "application/octet-stream; param1=\"value/1\"",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := fixUnquotedSpecials(tc.input)
+			if got != tc.want {
+				t.Errorf("\ngot:  %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestReadHeader(t *testing.T) {
 	prefix := "From: hooman\n \n being\n"
 	suffix := "Subject: hi\n\nPart body\n"

--- a/testdata/parts/unquoted-ctype-param-special.raw
+++ b/testdata/parts/unquoted-ctype-param-special.raw
@@ -1,0 +1,3 @@
+Content-Type: text/calendar; method=text/calendar
+Content-Disposition: attachment; filename=calendar.ics
+


### PR DESCRIPTION
This allowed handling Content-Type headers with parameters that contain unquoted special characters, like this:

	Content-Type: text/calendar; method=text/calendar

In that example, the `method` parameter contains a character that needs to be quoted (`/`), but is not.

This change reformats such parameters so they are quoted properly.