### PR TITLE
Better character set detection behavior

### DIFF
--- a/testdata/parts/chardet-fail-non-txt.raw
+++ b/testdata/parts/chardet-fail-non-txt.raw
@@ -1,0 +1,7 @@
+Content-Type: image/gif;
+	name="rzkly.gif"
+Content-Transfer-Encoding: base64
+Content-ID: <part3.E34FF3C4.059DAD00@example.com>
+
+R0lGODlhZAAEAIAAAABmzGb/mSH5BAAAAAAALAAAAABkAAQAAAIajI+py+0Po5y02uuA3rz7D4bi
+SJbmiabqKhYAOw==

--- a/testdata/parts/chardet-fail.raw
+++ b/testdata/parts/chardet-fail.raw
@@ -1,0 +1,7 @@
+Content-Type: text/plain;
+	name="rzkly.txt"
+Content-Transfer-Encoding: base64
+Content-ID: <part3.E34FF3C4.059DAD00@example.com>
+
+R0lGODlhZAAEAIAAAABmzGb/mSH5BAAAAAAALAAAAABkAAQAAAIajI+py+0Po5y02uuA3rz7D4bi
+SJbmiabqKhYAOw==


### PR DESCRIPTION
Only attempt to detect character set on `text/*` parts

On failure to detect character set, fall back to part-specified character set (which is what was used prior to charset detection being introduced) and add a warning to the part rather than fail to parse the message.