### PR TITLE
Remove CTE header if set in a part before encoding it.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -67,6 +67,11 @@ func (p *Part) Encode(writer io.Writer) error {
 // then sets the Content-Type (type, charset, filename, boundary) and Content-Disposition headers.
 func (p *Part) setupMIMEHeaders() transferEncoding {
 	// Determine content transfer encoding.
+
+	// If we are encoding a part that previously had content-transfer-encoding set, unset it so
+	// the correct encoding detection can be done below.
+	p.Header.Del(hnContentEncoding)
+
 	cte := te7Bit
 	if len(p.Content) > 0 {
 		cte = teBase64

--- a/encode_test.go
+++ b/encode_test.go
@@ -163,6 +163,19 @@ func TestEncodePartContentQuotable(t *testing.T) {
 	test.DiffGolden(t, b.Bytes(), "testdata", "encode", "part-quoted-content.golden")
 }
 
+func TestEncodePartWithExistingEncodingHeader(t *testing.T) {
+	p := enmime.NewPart("text/plain")
+	p.Header.Add("Content-Transfer-Encoding", "quoted-printable")
+	p.Content = []byte("Hello=")
+
+	b := &bytes.Buffer{}
+	err := p.Encode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	test.DiffGolden(t, b.Bytes(), "testdata", "encode", "part-quotable-content.golden")
+}
+
 func TestEncodePartContentBinary(t *testing.T) {
 	c := make([]byte, 2000)
 	for i := range c {

--- a/testdata/encode/part-quotable-content.golden
+++ b/testdata/encode/part-quotable-content.golden
@@ -1,0 +1,3 @@
+Content-Type: text/plain; charset=utf-8
+
+Hello=


### PR DESCRIPTION
In the case that a pre-existing part is decoded (e.g. from a pre-existing email), the content in an encoded part will be decoded correctly and the CTE header will be set based on the original part (e.g. quoted-printable). When encoding that part in the case that enmime's CTE detection decides that it should be 7bit, it did not remove the previous CTE header, resulting in a header specifying quoted-printable, but data that was encoded as 7bit.