### PR TITLE
Make ParseMediaType public

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -9,7 +9,7 @@ import (
 func detectMultipartMessage(root *Part) bool {
 	// Parse top-level multipart
 	ctype := root.Header.Get(hnContentType)
-	mediatype, _, _, err := parseMediaType(ctype)
+	mediatype, _, _, err := ParseMediaType(ctype)
 	if err != nil {
 		return false
 	}
@@ -29,13 +29,13 @@ func detectMultipartMessage(root *Part) bool {
 //  - Content-Disposition: inline; filename="frog.jpg"
 //  - Content-Type: attachment; filename="frog.jpg"
 func detectAttachmentHeader(header textproto.MIMEHeader) bool {
-	mediatype, params, _, _ := parseMediaType(header.Get(hnContentDisposition))
+	mediatype, params, _, _ := ParseMediaType(header.Get(hnContentDisposition))
 	if strings.ToLower(mediatype) == cdAttachment ||
 		(strings.ToLower(mediatype) == cdInline && len(params) > 0) {
 		return true
 	}
 
-	mediatype, _, _, _ = parseMediaType(header.Get(hnContentType))
+	mediatype, _, _, _ = ParseMediaType(header.Get(hnContentType))
 	return strings.ToLower(mediatype) == cdAttachment
 }
 
@@ -48,7 +48,7 @@ func detectTextHeader(header textproto.MIMEHeader, emptyContentTypeIsText bool) 
 		return true
 	}
 
-	mediatype, _, _, err := parseMediaType(ctype)
+	mediatype, _, _, err := ParseMediaType(ctype)
 	if err != nil {
 		return false
 	}
@@ -72,7 +72,7 @@ func detectBinaryBody(root *Part) bool {
 		// 'text/plain' or 'text/html'.
 		// Example:
 		// Content-Type: application/pdf; name="doc.pdf"
-		mediatype, _, _, _ := parseMediaType(root.Header.Get(hnContentType))
+		mediatype, _, _, _ := ParseMediaType(root.Header.Get(hnContentType))
 		mediatype = strings.ToLower(mediatype)
 		if mediatype != ctTextPlain && mediatype != ctTextHTML {
 			return true

--- a/envelope.go
+++ b/envelope.go
@@ -236,7 +236,7 @@ func parseTextOnlyBody(root *Part, e *Envelope) error {
 	var charset string
 	var isHTML bool
 	if ctype := root.Header.Get(hnContentType); ctype != "" {
-		if mediatype, mparams, _, err := parseMediaType(ctype); err == nil {
+		if mediatype, mparams, _, err := ParseMediaType(ctype); err == nil {
 			isHTML = (mediatype == ctTextHTML)
 			if mparams[hpCharset] != "" {
 				charset = mparams[hpCharset]
@@ -275,7 +275,7 @@ func parseTextOnlyBody(root *Part, e *Envelope) error {
 func parseMultiPartBody(root *Part, e *Envelope) error {
 	// Parse top-level multipart
 	ctype := root.Header.Get(hnContentType)
-	mediatype, params, _, err := parseMediaType(ctype)
+	mediatype, params, _, err := ParseMediaType(ctype)
 	if err != nil {
 		return fmt.Errorf("Unable to parse media type: %v", err)
 	}

--- a/header.go
+++ b/header.go
@@ -196,8 +196,13 @@ func decodeToUTF8Base64Header(input string) string {
 	return strings.Join(output, " ")
 }
 
-// parseMediaType is a more tolerant implementation of Go's mime.ParseMediaType function.
-func parseMediaType(ctype string) (mtype string, params map[string]string, invalidParams []string, err error) {
+// ParseMediaType is a more tolerant implementation of Go's mime.ParseMediaType function.
+//
+// Tolerances accounted for:
+//   * Missing ';' between content-type and media parameters
+//   * Repeating media parameters
+//   * Unquoted values in media parameters containing 'tspecials' characters
+func ParseMediaType(ctype string) (mtype string, params map[string]string, invalidParams []string, err error) {
 	mtype, params, err = mime.ParseMediaType(ctype)
 	if err != nil {
 		// Small hack to remove harmless charset duplicate params.

--- a/part.go
+++ b/part.go
@@ -113,7 +113,7 @@ func (p *Part) setupHeaders(r *bufio.Reader, defaultContentType string) error {
 		ctype = defaultContentType
 	}
 	// Parse Content-Type header.
-	mtype, mparams, minvalidParams, err := parseMediaType(ctype)
+	mtype, mparams, minvalidParams, err := ParseMediaType(ctype)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (p *Part) setupHeaders(r *bufio.Reader, defaultContentType string) error {
 // the disposition, filename, and charset fields.
 func (p *Part) setupContentHeaders(mediaParams map[string]string) {
 	// Determine content disposition, filename, character set.
-	disposition, dparams, _, err := parseMediaType(p.Header.Get(hnContentDisposition))
+	disposition, dparams, _, err := ParseMediaType(p.Header.Get(hnContentDisposition))
 	if err == nil {
 		// Disposition is optional
 		p.Disposition = disposition


### PR DESCRIPTION
In this PR I am proposing to make our "ParseMediaType" function available in the public api. In my project I have needed this for a thin stdlib pre-parser, to distinguish if I should even bother sending the bytes to enmime. The kind of realworld nuances we have navigated in this function, and the ones we have yet to navigate, make me want to avoid copy 'n paste solution.