### PR TITLE
Requaos/nontermboundry

### DIFF
--- a/boundary.go
+++ b/boundary.go
@@ -76,13 +76,13 @@ func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 	}
 
 	for i := 0; i < cap(dest); i++ {
-		c, err := b.r.Peek(1)
+		cs, err := b.r.Peek(1)
 		if err != nil && err != io.EOF {
 			return 0, errors.WithStack(err)
 		}
-		// Ensure that we can switch on the first byte of 'c' without panic.
-		if len(c) > 0 {
-			switch c[0] {
+		// Ensure that we can switch on the first byte of 'cs' without panic.
+		if len(cs) > 0 {
+			switch cs[0] {
 			// Check for line feed as potential LF boundary prefix.
 			case '\n':
 				peek, err := b.r.Peek(len(b.nlPrefix) + 2)

--- a/boundary.go
+++ b/boundary.go
@@ -3,6 +3,7 @@ package enmime
 import (
 	"bufio"
 	"bytes"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,7 +17,7 @@ import (
 // from it.
 const peekBufferSize = 4096
 
-var errNoBoundaryTerminator = errors.New("expected boundary not present")
+var errNoBoundaryTerminator = stderrors.New("expected boundary not present")
 
 type boundaryReader struct {
 	finished        bool          // No parts remain when finished

--- a/boundary.go
+++ b/boundary.go
@@ -80,10 +80,10 @@ func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 		if err != nil && err != io.EOF {
 			return 0, errors.WithStack(err)
 		}
-		// Ensure that we can switch on the first byte of 'c' without panic
+		// Ensure that we can switch on the first byte of 'c' without panic.
 		if len(c) > 0 {
 			switch c[0] {
-			// Check for line feed as potential LF boundary prefix
+			// Check for line feed as potential LF boundary prefix.
 			case '\n':
 				peek, err := b.r.Peek(len(b.nlPrefix) + 2)
 				switch err {
@@ -104,9 +104,9 @@ func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 							err = b.r.UnreadByte()
 							switch err {
 							case nil:
-								// Carry on
+								// Carry on.
 							case bufio.ErrInvalidUnreadByte:
-								// Carriage return boundary prefix bit already unread
+								// Carriage return boundary prefix bit already unread.
 							default:
 								return 0, errors.WithStack(err)
 							}
@@ -138,14 +138,14 @@ func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 						return 0, errors.WithStack(err)
 					}
 				}
-			// Check for carriage return as potential CRLF boundary prefix
+			// Check for carriage return as potential CRLF boundary prefix.
 			case '\r':
 				_, err := b.r.ReadByte()
 				if err != nil {
 					return 0, errors.WithStack(err)
 				}
 				// Flag the boundary reader to indicate that we
-				// have stored a '\r' as a potential CRLF prefix
+				// have stored a '\r' as a potential CRLF prefix.
 				b.crBoundaryPrefix = true
 				continue
 			}
@@ -153,8 +153,7 @@ func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 
 		_, err = io.CopyN(b.buffer, b.r, 1)
 		if err != nil {
-			// EOF is not fatal, it just means
-			// that we have drained the reader.
+			// EOF is not fatal, it just means that we have drained the reader.
 			if errors.Cause(err) == io.EOF {
 				break
 			}
@@ -173,7 +172,7 @@ func (b *boundaryReader) Next() (bool, error) {
 		return false, nil
 	}
 	if b.partsRead > 0 {
-		// Exhaust the current part to prevent errors when moving to the next part
+		// Exhaust the current part to prevent errors when moving to the next part.
 		_, _ = io.Copy(ioutil.Discard, b)
 	}
 	for {
@@ -190,17 +189,17 @@ func (b *boundaryReader) Next() (bool, error) {
 			return false, nil
 		}
 		if err != io.EOF && b.isDelimiter(line) {
-			// Start of a new part
+			// Start of a new part.
 			b.partsRead++
 			return true, nil
 		}
 		if err == io.EOF {
-			// Intentionally not wrapping with stack
+			// Intentionally not wrapping with stack.
 			return false, io.EOF
 		}
 		if b.partsRead == 0 {
 			// The first part didn't find the starting delimiter, burn off any preamble in front of
-			// the boundary
+			// the boundary.
 			continue
 		}
 		b.finished = true
@@ -215,7 +214,7 @@ func (b *boundaryReader) isDelimiter(buf []byte) bool {
 		return false
 	}
 
-	// Fast forward to the end of the boundary prefix
+	// Fast forward to the end of the boundary prefix.
 	buf = buf[idx+len(b.prefix):]
 	if len(buf) > 0 {
 		if unicode.IsSpace(rune(buf[0])) {

--- a/boundary.go
+++ b/boundary.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	stderrors "errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"unicode"
@@ -205,7 +204,7 @@ func (b *boundaryReader) Next() (bool, error) {
 			continue
 		}
 		b.finished = true
-		return false, errors.WithMessage(errNoBoundaryTerminator, fmt.Sprintf("expecting boundary %q, got %q", string(b.prefix), string(line)))
+		return false, errors.WithMessagef(errNoBoundaryTerminator, "expecting boundary %q, got %q", string(b.prefix), string(line))
 	}
 }
 

--- a/boundary_test.go
+++ b/boundary_test.go
@@ -290,8 +290,8 @@ func TestBoundaryReaderNoTerminator(t *testing.T) {
 		t.Fatal("Next() = false, want: true")
 	}
 
-	// Second part should error
-	want := "expecting boundary"
+	// There is no second part should, error should be EOF
+	want := "EOF"
 	next, err = br.Next()
 	if err == nil {
 		t.Fatal("Error was nil, wanted:", want)

--- a/boundary_test.go
+++ b/boundary_test.go
@@ -19,6 +19,11 @@ func TestBoundaryReader(t *testing.T) {
 			want:     "good",
 		},
 		{
+			input:    "good\r\n--STOPHERE\t\r\nafter",
+			boundary: "STOPHERE",
+			want:     "good",
+		},
+		{
 			input:    "good\r\n--STOPHERE--\r\nafter",
 			boundary: "STOPHERE",
 			want:     "good",

--- a/boundary_test.go
+++ b/boundary_test.go
@@ -295,7 +295,7 @@ func TestBoundaryReaderNoTerminator(t *testing.T) {
 		t.Fatal("Next() = false, want: true")
 	}
 
-	// There is no second part should, error should be EOF
+	// There is no second part should, error should be EOF.
 	want := "EOF"
 	next, err = br.Next()
 	if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/jaytaylor/html2text v0.0.0-20180606194806-57d518f124b0
 	github.com/mattn/go-runewidth v0.0.3 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc // indirect
-	github.com/pkg/errors v0.8.0
+	github.com/pkg/errors v0.8.1
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	golang.org/x/net v0.0.0-20181017193950-04a2e542c03f // indirect

--- a/testdata/parts/multimixed-no-closing-boundary.raw
+++ b/testdata/parts/multimixed-no-closing-boundary.raw
@@ -1,0 +1,12 @@
+Content-Type: multipart/mixed; boundary="Enmime-Test-100"
+
+--Enmime-Test-100
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+<body>
+<p><font color=3D"navy" face=3D"Segoe UI">
+=0DHello,
+ </font></p>
+<br>


### PR DESCRIPTION
Had an issue where the boundary was not terminated, and I saw some tests around this but my case fell through the cracks. I refactored the `Read()` function to go one byte at a time and only peek the length of the `fullBoundary`.
(edited)
There was a case where the boundary was being detected 2x chars early for whitespace at the head, resolved in b6a4d4e