### PR TITLE
return empty string and nil error if content-type is empty so that en…

### DIFF
--- a/header.go
+++ b/header.go
@@ -224,11 +224,11 @@ func quotedDisplayName(s string) string {
 func ParseMediaType(ctype string) (mtype string, params map[string]string, invalidParams []string, err error) {
 	mtype, params, err = mime.ParseMediaType(ctype)
 	if err != nil {
-		// Small hack to remove harmless charset duplicate params.
-		mctype := fixMangledMediaType(ctype, ";")
-		if mctype == "" {
+		if err.Error() == "mime: no media type" {
 			return "", nil, nil, nil
 		}
+		// Small hack to remove harmless charset duplicate params.
+		mctype := fixMangledMediaType(ctype, ";")
 		mtype, params, err = mime.ParseMediaType(mctype)
 		if err != nil {
 			// Some badly formed media types forget to send ; between fields.

--- a/header.go
+++ b/header.go
@@ -226,6 +226,9 @@ func ParseMediaType(ctype string) (mtype string, params map[string]string, inval
 	if err != nil {
 		// Small hack to remove harmless charset duplicate params.
 		mctype := fixMangledMediaType(ctype, ";")
+		if mctype == "" {
+			return "", nil, nil, nil
+		}
 		mtype, params, err = mime.ParseMediaType(mctype)
 		if err != nil {
 			// Some badly formed media types forget to send ; between fields.

--- a/part.go
+++ b/part.go
@@ -296,12 +296,13 @@ func (p *Part) decodeContent(r io.Reader) error {
 	// Collect base64 errors.
 	if b64cleaner != nil {
 		for _, err := range b64cleaner.Errors {
-			p.Errors = append(p.Errors, &Error{
-				Name:   ErrorMalformedBase64,
-				Detail: err.Error(),
-				Severe: false,
-			})
+			p.addWarning(ErrorMalformedBase64, err.Error())
 		}
+	}
+	// Set empty content-type error
+	if p.ContentType == "" {
+		p.addWarning(
+			ErrorMissingContentType, "content-type is empty for part id: %s", p.PartID)
 	}
 	return nil
 }

--- a/part.go
+++ b/part.go
@@ -299,7 +299,7 @@ func (p *Part) decodeContent(r io.Reader) error {
 			p.addWarning(ErrorMalformedBase64, err.Error())
 		}
 	}
-	// Set empty content-type error
+	// Set empty content-type error.
 	if p.ContentType == "" {
 		p.addWarning(
 			ErrorMissingContentType, "content-type is empty for part id: %s", p.PartID)

--- a/part_test.go
+++ b/part_test.go
@@ -772,6 +772,38 @@ func TestBarrenContentType(t *testing.T) {
 	}
 }
 
+func TestEmptyContentTypeBadContent(t *testing.T) {
+	r := test.OpenTestData("parts", "empty-ctype-bad-content.raw")
+	p, err := enmime.ReadParts(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantp := &enmime.Part{
+		PartID:      "1",
+		Parent:      test.PartExists,
+		Disposition: "",
+	}
+	test.ComparePart(t, p.FirstChild, wantp)
+
+	expected := enmime.ErrorMissingContentType
+	satisfied := false
+	for _, perr := range p.FirstChild.Errors {
+		if perr.Name == expected {
+			satisfied = true
+			if perr.Severe {
+				t.Errorf("Expected Severe to be false, got true for %q", perr.Name)
+			}
+		}
+	}
+	if !satisfied {
+		t.Errorf(
+			"Did not find expected error on part. Expected %q, but had: %v",
+			expected,
+			p.Errors)
+	}
+}
+
 func TestMalformedContentTypeParams(t *testing.T) {
 	r := test.OpenTestData("parts", "malformed-content-type-params.raw")
 	p, err := enmime.ReadParts(r)

--- a/testdata/parts/empty-ctype-bad-content.raw
+++ b/testdata/parts/empty-ctype-bad-content.raw
@@ -1,0 +1,20 @@
+Content-Type: multipart/alternative; boundary="----=_Part_10541_215446765.98298273965074084"
+
+------=_Part_10541_215446765.98298273965074084
+Content-Type: <html>
+
+Use the View Invoices function or locate the account on the List of Accounts table.<br>
+<br>
+Please do not reply to this e-mail message.<br>
+<br>
+Your Team<br>
+<br>
+<br>
+If you have received this notification in error, or if you need further assistance accessing your invoice, please contact us.<br>
+</font></p>
+</body>
+</html>
+Content-Transfer-Encoding: quoted-printable
+
+
+------=_Part_10541_215446765.98298273965074084--


### PR DESCRIPTION
…mime.ErrorMissingContentType can be added to the errors slice and continue parsing