### PR TITLE
Propper detection of text/plain attachment.

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -63,6 +63,16 @@ func detectTextHeader(header textproto.MIMEHeader, emptyContentTypeIsText bool) 
 // detectBinaryBody returns true if the mail header defines a binary body.
 func detectBinaryBody(root *Part) bool {
 	if detectTextHeader(root.Header, true) {
+		// It is text/plain, but an attachment.
+		// Content-Type: text/plain; name="test.csv"
+		// Content-Disposition: attachment; filename="test.csv"
+		// Check for attachment only, or inline body is marked
+		// as attachment, too.
+		mediatype, _, _, _ := ParseMediaType(root.Header.Get(hnContentDisposition))
+		if strings.ToLower(mediatype) == cdAttachment {
+			return true
+		}
+
 		return false
 	}
 

--- a/detect.go
+++ b/detect.go
@@ -69,11 +69,7 @@ func detectBinaryBody(root *Part) bool {
 		// Check for attachment only, or inline body is marked
 		// as attachment, too.
 		mediatype, _, _, _ := ParseMediaType(root.Header.Get(hnContentDisposition))
-		if strings.ToLower(mediatype) == cdAttachment {
-			return true
-		}
-
-		return false
+		return strings.ToLower(mediatype) == cdAttachment
 	}
 
 	isBin := detectAttachmentHeader(root.Header)

--- a/detect_test.go
+++ b/detect_test.go
@@ -51,6 +51,7 @@ func TestDetectBinaryBody(t *testing.T) {
 		{filename: "attachment-only.raw", disposition: "attachment"},
 		{filename: "attachment-only-inline.raw", disposition: "inline"},
 		{filename: "attachment-only-no-disposition.raw", disposition: "none"},
+		{filename: "attachment-only-text-attachment.raw", disposition: "attachment"},
 	}
 	for _, tt := range ttable {
 		r, _ := os.Open(filepath.Join("testdata", "mail", tt.filename))

--- a/testdata/mail/attachment-only-text-attachment.raw
+++ b/testdata/mail/attachment-only-text-attachment.raw
@@ -1,0 +1,11 @@
+To: bob@test.com
+From: alice@test.com
+Subject: Test
+Message-ID: <56A0AA5F.4020203@test.com>
+Date: Thu, 21 Jan 2016 10:52:31 +0100
+MIME-Version: 1.0
+Content-Type: text/plain; name="test.csv"
+Content-Disposition: attachment; filename="test.csv"
+Content-Transfer-Encoding: base64
+
+VGVzdDtUZXN0Cg==


### PR DESCRIPTION
Mail with content headers

Content-Type: text/plain; name="test.csv"
Content-Disposition: attachment; filename="test.csv"

is parsed incorrectly. The CSV attachment is used as text body.