### PR TITLE
mime: invalid media parameter

### DIFF
--- a/header.go
+++ b/header.go
@@ -383,6 +383,13 @@ findValueStart:
 
 			break findValueStart
 
+		case ';':
+			if value.Len() == 0 {
+				value.WriteString(`"";`)
+			}
+
+			break findValueStart
+
 		default:
 			valueQuotedOriginally = false
 			valueQuoteAdded = false

--- a/header_test.go
+++ b/header_test.go
@@ -332,6 +332,10 @@ func TestFixUnquotedSpecials(t *testing.T) {
 			want:  `text/html;charset=""`,
 		},
 		{
+			input: `text/html; charset=; format=flowed`,
+			want:  `text/html; charset=""; format=flowed`,
+		},
+		{
 			input: `text/html;charset="`,
 			want:  `text/html;charset=""`,
 		},


### PR DESCRIPTION
While we handle media parameters with missing values if they are the last parameter, this fix allows for the handling of media parameters missing value in the middle of the parameter list.