### PR TITLE
mime: expected slash after first token

### DIFF
--- a/header.go
+++ b/header.go
@@ -277,6 +277,11 @@ func fixMangledMediaType(mtype, sep string) string {
 	}
 	parts := strings.Split(mtype, sep)
 	mtype = ""
+	if strings.Contains(parts[0], "=") {
+		// A parameter pair at this position indicates we are missing a content-type.
+		parts[0] = fmt.Sprintf("%s%s %s", ctAppOctetStream, sep, parts[0])
+		parts = strings.Split(strings.Join(parts, sep), sep)
+	}
 	for i, p := range parts {
 		switch i {
 		case 0:

--- a/header_test.go
+++ b/header_test.go
@@ -215,6 +215,11 @@ func TestFixMangledMediaType(t *testing.T) {
 			want:  ctPlaceholder + "; name=\"file.two\"",
 		},
 		{
+			input: "charset=binary; name=\"logoleft.jpg\"",
+			sep:   ";",
+			want:  "application/octet-stream; charset=binary; name=\"logoleft.jpg\"",
+		},
+		{
 			input: "one/two;iso-8859-1",
 			sep:   ";",
 			want:  "one/two;iso-8859-1=" + pvPlaceholder,


### PR DESCRIPTION
Found occurrences of a media parameter list without a mime type, this will inject a safe default mime type.