### PR TITLE
Handle very empty MIME part

### DIFF
--- a/boundary.go
+++ b/boundary.go
@@ -21,6 +21,7 @@ var errNoBoundaryTerminator = stderrors.New("expected boundary not present")
 type boundaryReader struct {
 	finished         bool          // No parts remain when finished
 	partsRead        int           // Number of parts read thus far
+	atPartStart      bool          // Whether the current part is at its beginning
 	r                *bufio.Reader // Source reader
 	nlPrefix         []byte        // NL + MIME boundary prefix
 	prefix           []byte        // MIME boundary prefix
@@ -72,7 +73,12 @@ func newBoundaryReader(reader *bufio.Reader, boundary string) *boundaryReader {
 func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 	if b.buffer.Len() >= len(dest) {
 		// This read request can be satisfied entirely by the buffer.
-		return b.buffer.Read(dest)
+		n, err = b.buffer.Read(dest)
+		if b.atPartStart && n > 0 {
+			b.atPartStart = false
+		}
+
+		return n, err
 	}
 
 	for i := 0; i < cap(dest); i++ {
@@ -93,6 +99,14 @@ func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 			// Check for line feed as potential LF boundary prefix.
 			case '\n':
 				check = true
+
+			default:
+				if b.atPartStart {
+					// If we're at the very beginning of the part (even before the headers),
+					// check to see if there's a delimiter that immediately follows.
+					padding = 0
+					check = true
+				}
 			}
 
 			if check {
@@ -113,6 +127,9 @@ func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 						n, err = b.buffer.Read(dest)
 						switch err {
 						case nil, io.EOF:
+							if b.atPartStart && n > 0 {
+								b.atPartStart = false
+							}
 							return n, io.EOF
 						default:
 							return 0, errors.WithStack(err)
@@ -141,6 +158,9 @@ func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 
 	// Read the contents of the buffer into the destination slice.
 	n, err = b.buffer.Read(dest)
+	if b.atPartStart && n > 0 {
+		b.atPartStart = false
+	}
 	return n, err
 }
 
@@ -169,6 +189,7 @@ func (b *boundaryReader) Next() (bool, error) {
 		if err != io.EOF && b.isDelimiter(line) {
 			// Start of a new part.
 			b.partsRead++
+			b.atPartStart = true
 			return true, nil
 		}
 		if err == io.EOF {

--- a/boundary_test.go
+++ b/boundary_test.go
@@ -186,6 +186,21 @@ func TestBoundaryReaderParts(t *testing.T) {
 			boundary: "STOP",
 			parts:    []string{"part1", "part2"},
 		},
+		{
+			input:    "--STOP\npart1\n--STOP\n--STOP--\n",
+			boundary: "STOP",
+			parts:    []string{"part1", ""},
+		},
+		{
+			input:    "--STOP\n--STOP\npart2\n--STOP--\n",
+			boundary: "STOP",
+			parts:    []string{"", "part2"},
+		},
+		{
+			input:    "--STOP\n--STOP\n--STOP--\n",
+			boundary: "STOP",
+			parts:    []string{"", ""},
+		},
 	}
 
 	for _, tt := range ttable {


### PR DESCRIPTION
When one MIME boundary immediately follows another, treat it as an empty part.

This comes from an issue I saw in a production environment where there was an email where a MIME part delimiter was immediately followed by a terminator. Like this:

```txt
Content-type: multipart/mixed; boundary="the-boundary"

--the-boundary
Content-type: text/plain

Some content.

--the-boundary
--the-boundary--
```