### PR TITLE
Read into destination by length, not capacity

### DIFF
--- a/boundary.go
+++ b/boundary.go
@@ -75,7 +75,7 @@ func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 		return b.buffer.Read(dest)
 	}
 
-	for i := 0; i < cap(dest); i++ {
+	for i := 0; i < len(dest); i++ {
 		cs, err := b.r.Peek(1)
 		if err != nil && err != io.EOF {
 			return 0, errors.WithStack(err)


### PR DESCRIPTION
Fixes the `boundaryReader` implementation of `io.Reader` to fill the slice based on its length, not its capacity. As per [the `io.Reader` documentation](https://pkg.go.dev/io?tab=doc#Reader).