### PR TITLE
Adds Part.ContentTypeParams to allow custom params

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -100,6 +100,9 @@ func (p *Part) setupMIMEHeaders() transferEncoding {
 	if p.ContentType != "" {
 		// Build content type header.
 		param := make(map[string]string)
+		for k, v := range p.ContentTypeParams {
+			param[k] = v
+		}
 		setParamValue(param, hpCharset, p.Charset)
 		setParamValue(param, hpName, stringutil.ToASCII(p.FileName))
 		setParamValue(param, hpBoundary, p.Boundary)

--- a/encode_test.go
+++ b/encode_test.go
@@ -48,6 +48,8 @@ func TestEncodePartDefaultHeaders(t *testing.T) {
 	p.Boundary = "enmime-abcdefg0123456789"
 	p.Charset = "binary"
 	p.ContentID = "mycontentid"
+	p.ContentTypeParams["param1"] = "myparameter1"
+	p.ContentTypeParams["param2"] = "myparameter2"
 	p.Disposition = "attachment"
 	p.FileName = "stuff.zip"
 	p.FileModDate, _ = time.Parse(time.RFC822, "01 Feb 03 04:05 GMT")
@@ -66,6 +68,8 @@ func TestEncodePartQuotedHeaders(t *testing.T) {
 	p.Boundary = "enmime-abcdefg0123456789"
 	p.Charset = "binary"
 	p.ContentID = "mycontentid"
+	p.ContentTypeParams["param1"] = "myparameter1"
+	p.ContentTypeParams["param2"] = "myparameter2"
 	p.Disposition = "attachment"
 	p.FileName = `árvíztűrő "x" tükörfúrógép.zip`
 	p.FileModDate, _ = time.Parse(time.RFC822, "01 Feb 03 04:05 GMT")
@@ -84,6 +88,8 @@ func TestEncodePartQuotedPrintableHeaders(t *testing.T) {
 	p.Boundary = "enmime-abcdefg0123456789"
 	p.Charset = "binary"
 	p.ContentID = "mycontentid"
+	p.ContentTypeParams["param1"] = "myparameter1"
+	p.ContentTypeParams["param2"] = "myparameter2"
 	p.Disposition = "attachment"
 	p.FileName = `árvíztűrő "x" tükörfúrógép.zip`
 	p.FileModDate, _ = time.Parse(time.RFC822, "01 Feb 03 04:05 GMT")

--- a/part.go
+++ b/part.go
@@ -31,14 +31,15 @@ type Part struct {
 	NextSibling *Part                // NextSibling of this part.
 	Header      textproto.MIMEHeader // Header for this Part.
 
-	Boundary    string    // Boundary marker used within this part.
-	ContentID   string    // ContentID header for cid URL scheme.
-	ContentType string    // ContentType header without parameters.
-	Disposition string    // Content-Disposition header without parameters.
-	FileName    string    // The file-name from disposition or type header.
-	FileModDate time.Time // The modification date of the file.
-	Charset     string    // The content charset encoding, may differ from charset in header.
-	OrigCharset string    // The original content charset when a different charset was detected.
+	Boundary          string            // Boundary marker used within this part.
+	ContentID         string            // ContentID header for cid URL scheme.
+	ContentType       string            // ContentType header without parameters.
+	ContentTypeParams map[string]string // Params, added to ContentType header.
+	Disposition       string            // Content-Disposition header without parameters.
+	FileName          string            // The file-name from disposition or type header.
+	FileModDate       time.Time         // The modification date of the file.
+	Charset           string            // The content charset encoding, may differ from charset in header.
+	OrigCharset       string            // The original content charset when a different charset was detected.
 
 	Errors   []*Error // Errors encountered while parsing this part.
 	Content  []byte   // Content after decoding, UTF-8 conversion if applicable.
@@ -48,8 +49,9 @@ type Part struct {
 // NewPart creates a new Part object.
 func NewPart(contentType string) *Part {
 	return &Part{
-		Header:      make(textproto.MIMEHeader),
-		ContentType: contentType,
+		Header:            make(textproto.MIMEHeader),
+		ContentType:       contentType,
+		ContentTypeParams: make(map[string]string),
 	}
 }
 

--- a/testdata/encode/part-default-headers.golden
+++ b/testdata/encode/part-default-headers.golden
@@ -3,6 +3,6 @@ Content-Disposition: attachment; filename=stuff.zip; modification-date="01
 Content-Id: <mycontentid>
 Content-Transfer-Encoding: base64
 Content-Type: application/zip; boundary=enmime-abcdefg0123456789;
- charset=binary; name=stuff.zip
+ charset=binary; name=stuff.zip; param1=myparameter1; param2=myparameter2
 
 WklQWklQWklQ

--- a/testdata/encode/part-quoted-headers.golden
+++ b/testdata/encode/part-quoted-headers.golden
@@ -3,6 +3,7 @@ Content-Disposition: attachment; filename="arvizturo \"x\"
 Content-Id: <mycontentid>
 Content-Transfer-Encoding: base64
 Content-Type: application/zip; boundary=enmime-abcdefg0123456789;
- charset=binary; name="arvizturo \"x\" tukorfurogep.zip"
+ charset=binary; name="arvizturo \"x\" tukorfurogep.zip";
+ param1=myparameter1; param2=myparameter2
 
 WklQWklQWklQ

--- a/testdata/encode/part-quoted-printable-headers.golden
+++ b/testdata/encode/part-quoted-printable-headers.golden
@@ -3,7 +3,8 @@ Content-Disposition: attachment; filename="arvizturo \"x\"
 Content-Id: <mycontentid>
 Content-Transfer-Encoding: base64
 Content-Type: application/zip; boundary=enmime-abcdefg0123456789;
- charset=binary; name="arvizturo \"x\" tukorfurogep.zip"
+ charset=binary; name="arvizturo \"x\" tukorfurogep.zip";
+ param1=myparameter1; param2=myparameter2
 X-Qp-Header: =?utf-8?q?Just_enough_to_need_qp_=E2=98=86?=
 
 WklQWklQWklQ


### PR DESCRIPTION
 Custom ContentTypeParams are required in certain situations.
 E.g. RFC3156 (MIME Security for OpenPGP) requires
 protocol="application/pgp-encrypted" as Content-Type param.