### PR TITLE
Header line incorrectly beginning with a space

### DIFF
--- a/header.go
+++ b/header.go
@@ -101,10 +101,21 @@ func readHeader(r *bufio.Reader, p *Part) (textproto.MIMEHeader, error) {
 		firstColon := bytes.IndexByte(s, ':')
 		firstSpace := bytes.IndexAny(s, " \t\n\r")
 		if firstSpace == 0 {
-			// Starts with space: continuation
-			buf.WriteByte(' ')
-			buf.Write(textproto.TrimBytes(s))
-			continue
+			// If there is a single colon followed immediately by a space and there
+			// is no equal sign, or comes before any equal sign, then it should not
+			// be considered as a continuation.
+			colonSpaceIdx := bytes.Index(s, []byte{':', ' '})
+			equalIdx := bytes.IndexByte(s, '=')
+			if bytes.Count(s, []byte{':'}) == 1 && colonSpaceIdx != -1 &&
+				(equalIdx == -1 || equalIdx > colonSpaceIdx) {
+				s = textproto.TrimBytes(s)
+				firstColon = bytes.IndexByte(s, ':')
+			} else {
+				// Starts with space: continuation
+				buf.WriteByte(' ')
+				buf.Write(textproto.TrimBytes(s))
+				continue
+			}
 		}
 		if firstColon == 0 {
 			// Can't parse line starting with colon: skip

--- a/header_test.go
+++ b/header_test.go
@@ -511,6 +511,12 @@ func TestReadHeader(t *testing.T) {
 			correct: true,
 		},
 		{
+			input:   "X-Not-Continuation: line1=foo;\n X-Next-Header: bar\n",
+			hname:   "X-Not-Continuation",
+			want:    "line1=foo;",
+			correct: true,
+		},
+		{
 			input: "Authentication-Results: mx.google.com;\n" +
 				"       spf=pass (google.com: sender)\n" +
 				"       dkim=pass header.i=@1;\n" +


### PR DESCRIPTION
results in "mime: invalid media parameter" error

This is a best effort attempt to correct an invalid continuation.