### PR TITLE
Handle trailing separators in header

### DIFF
--- a/header.go
+++ b/header.go
@@ -287,6 +287,11 @@ func fixMangledMediaType(mtype, sep string) string {
 				}
 			}
 		default:
+			if len(p) == 0 {
+				// Ignore trailing separators.
+				continue
+			}
+
 			if !strings.Contains(p, "=") {
 				p = p + "=" + pvPlaceholder
 			}

--- a/header_test.go
+++ b/header_test.go
@@ -190,6 +190,11 @@ func TestFixMangledMediaType(t *testing.T) {
 			want:  "multipart/mixed;charset=",
 		},
 		{
+			input: "text/plain;",
+			sep:   ";",
+			want:  "text/plain",
+		},
+		{
 			input: "application/octet-stream;=?UTF-8?B?bmFtZT0iw7DCn8KUwoo=?=You've got a new voice miss call.msg",
 			sep:   ";",
 			want:  "application/octet-stream;name=\"ð\u009f\u0094\u008aYou've got a new voice miss call.msg\"",


### PR DESCRIPTION
Hello. This is a fix for https://github.com/jhillyerd/enmime/issues/153.

If my understanding is correct, here is what was happening. When the `Content-Type` header value was something like `text/plain;`, it would turn into `text/plain;=not-a-param-value`, then `=not-a-param-value` parsed on its own would cause a `mime: invalid media parameter` error in turn.

Thanks!