### PR TITLE
fix: using dfs locate html body

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -300,7 +300,7 @@ func parseMultiPartBody(root *Part, e *Envelope) error {
 	}
 
 	// Locate HTML body
-	p := root.BreadthMatchFirst(matchHTMLBodyPart)
+	p := root.DepthMatchFirst(matchHTMLBodyPart)
 	if p != nil {
 		e.HTML += string(p.Content)
 	}

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -160,6 +160,20 @@ func TestParseMultiMixedText(t *testing.T) {
 	}
 }
 
+func TestParseMultiMixedRelatedHtml(t *testing.T) {
+	msg := test.OpenTestData("mail", "mime-mixed-related.raw")
+	e, err := enmime.ReadEnvelope(msg)
+
+	if err != nil {
+		t.Fatal("Failed to parse MIME:", err)
+	}
+
+	want := "<p>html1</p>"
+	if e.HTML != want {
+		t.Error("Text parts should concatenate, got:", e.HTML, "want:", want)
+	}
+}
+
 func TestParseMultiSignedText(t *testing.T) {
 	msg := test.OpenTestData("mail", "mime-signed.raw")
 	e, err := enmime.ReadEnvelope(msg)

--- a/testdata/mail/mime-mixed-related.raw
+++ b/testdata/mail/mime-mixed-related.raw
@@ -1,0 +1,37 @@
+Message-ID: <5081A889.3020108@jamehi03lx.noa.com>
+Date: Fri, 19 Oct 2012 12:22:49 -0700
+From: James Hillyerd <jamehi03@jamehi03lx.noa.com>
+User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0) Gecko/20121010 Thunderbird/16.0.1
+MIME-Version: 1.0
+To: greg@inbucket.com
+Subject: Multipart Mixed
+Content-Type: multipart/mixed; boundary="Enmime-Test-100"
+
+--Enmime-Test-100
+Content-Type: multipart/related; boundary="Enmime-Test-101"; type="multipart/alternative"
+
+--Enmime-Test-101
+Content-Type: multipart/alternative; boundary="Enmime-Test-102";
+MIME-Version: 1.0
+
+--Enmime-Test-102
+Content-Type: text/html; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: quoted-printable
+
+<p>html1</p>
+--Enmime-Test-102--
+--Enmime-Test-101--
+
+--Enmime-Test-100
+Content-Type: multipart/alternative; boundary="Enmime-Test-103";
+MIME-Version: 1.0
+
+--Enmime-Test-103
+Content-Type: text/html; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: quoted-printable
+
+<p>html2</p>
+--Enmime-Test-103--
+--Enmime-Test-100--


### PR DESCRIPTION
i found outlook mail service genrate an eml struct like:
- multipart/mixed
- - multipart/related
- - - multipart/alternative
- - - - text/plain (real mail content)
- - - - text/html (real mail content)
- - multipart/alternative
- - - text/plain (contact info)
- - - text/html (contact info)

bfs(first) will locate the wrong html(contact info), i checked Apache mail common, using dfs(first) to locate html, btw macOS mail client and outlook client dfs all content, not just first