### PR TITLE
fixUnescapedQuotes fixed for higher Unicode codepoints

### DIFF
--- a/header.go
+++ b/header.go
@@ -583,7 +583,7 @@ func fixUnescapedQuotes(hvalue string) string {
 		}
 		param = param[startingQuote+1 : closingQuote]
 		escaped := false
-		for strIdx := range param {
+		for strIdx := range []byte(param) {
 			switch param[strIdx] {
 			case '"':
 				// We are inside of a quoted string, so lets escape this guy if it isn't already escaped.

--- a/header_test.go
+++ b/header_test.go
@@ -407,6 +407,14 @@ func TestFixUnEscapedQuotes(t *testing.T) {
 			input: "application/rtf; charset=iso-8859-1; name=\"V047411.rtf;\".rtf",
 			want:  "application/rtf; charset=iso-8859-1; name=\"\\\"V047411.rtf;\\\".rtf\"",
 		},
+		{
+			input: "application/rtf; charset=utf-8; name=\"žába.jpg\"",
+			want:  "application/rtf; charset=utf-8; name=\"žába.jpg\"",
+		},
+		{
+			input: "application/rtf; charset=utf-8; name=\"\"žába\".jpg\"",
+			want:  "application/rtf; charset=utf-8; name=\"\\\"žába\\\".jpg\"",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {


### PR DESCRIPTION
String is expected to be iterated by bytes, but was by runes.