### PR TITLE
Improve performance of boundaryReader

### DIFF
--- a/boundary.go
+++ b/boundary.go
@@ -146,13 +146,19 @@ func (b *boundaryReader) Read(dest []byte) (n int, err error) {
 			}
 		}
 
-		_, err = io.CopyN(b.buffer, b.r, 1)
+		next, err := b.r.ReadByte()
 		if err != nil {
 			// EOF is not fatal, it just means that we have drained the reader.
-			if errors.Cause(err) == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
-			return 0, err
+
+			return 0, errors.WithStack(err)
+		}
+
+		err = b.buffer.WriteByte(next)
+		if err != nil {
+			return 0, errors.WithStack(err)
 		}
 	}
 

--- a/boundary_test.go
+++ b/boundary_test.go
@@ -520,3 +520,20 @@ func TestReadLenNotCap(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkBoundaryReader(b *testing.B) {
+	const (
+		input    = "content\r\n--BOUNDARY\r\n"
+		boundary = "BOUNDARY"
+	)
+
+	var err error
+	for i := 0; i < b.N; i++ {
+		ir := bufio.NewReader(strings.NewReader(input))
+		br := newBoundaryReader(ir, boundary)
+		_, err = io.Copy(ioutil.Discard, br)
+		if err != nil {
+			b.Fatalf("Failed to read content: %+v", err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jaytaylor/html2text v0.0.0-20190408195923-01ec452cbe43
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/olekukonko/tablewriter v0.0.1 // indirect
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca h1:NugYot0LIVPxTvN8n+Kvkn6TrbMyxQiuvKdEwFdR9vI=
 github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
 github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf h1:pvbZ0lM0XWPBqUKqFU8cmavspvIl9nulOYwdy6IFRRo=


### PR DESCRIPTION
Explicitly read/write a single byte rather than using `io.CopyN` to copy a single byte.

Before the change:

```
BenchmarkBoundaryReader-12    	  544516	      1909 ns/op	    6704 B/op	      15 allocs/op
```

After:
```
BenchmarkBoundaryReader-12    	 1039579	      1067 ns/op	    4495 B/op	       7 allocs/op
```

From 15 allocs/op down to 7.

Fixes #169.