### PR TITLE
modified Locate inlines code

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -312,7 +312,7 @@ func parseMultiPartBody(root *Part, e *Envelope) error {
 
 	// Locate inlines
 	e.Inlines = root.BreadthMatchAll(func(p *Part) bool {
-		return p.Disposition == cdInline && !strings.HasPrefix(p.ContentType, ctMultipartPrefix)
+		return (p.Disposition == cdInline && !strings.HasPrefix(p.ContentType, ctMultipartPrefix)) || (p.Disposition == "" && strings.HasPrefix(p.ContentType, "image") )
 	})
 
 	// Locate others parts not considered in attachments or inlines


### PR DESCRIPTION
consider image as inline if the content -disposition header is missing