### PR TITLE
Builder: allow empty subject line

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -221,9 +221,6 @@ func (p MailBuilder) Build() (*Part, error) {
 	if p.from.Address == "" {
 		return nil, errors.New("from not set")
 	}
-	if p.subject == "" {
-		return nil, errors.New("subject not set")
-	}
 	if len(p.to)+len(p.cc)+len(p.bcc) == 0 {
 		return nil, errors.New(ErrorMissingRecipient)
 	}

--- a/builder_test.go
+++ b/builder_test.go
@@ -833,14 +833,6 @@ func TestValidation(t *testing.T) {
 	if err == nil {
 		t.Error("error nil, expected value")
 	}
-
-	_, err = enmime.Builder().
-		To("name", "address").
-		From("name", "address").
-		Build()
-	if err == nil {
-		t.Error("error nil, expected value")
-	}
 }
 
 func TestBuilderFullStructure(t *testing.T) {


### PR DESCRIPTION
This is valid for email systems and sometimes necessary, especially
when you don't have direct control over the souce input.

Fixes #160