### PR TITLE
Remove whitespace between parameter=value and ; in headers

### DIFF
--- a/header.go
+++ b/header.go
@@ -308,6 +308,10 @@ func fixMangledMediaType(mtype string, sep rune) string {
 		// Only terminate with semicolon if not the last parameter and if it doesn't already have a
 		// semicolon.
 		if i != len(parts)-1 && !strings.HasSuffix(mtype, ";") {
+			// Remove whitespace between parameter=value and ;
+			for strings.HasSuffix(mtype, " ") || strings.HasSuffix(mtype, "\t") {
+				mtype = mtype[:len(mtype)-1]
+			}
 			mtype += ";"
 		}
 	}

--- a/header_test.go
+++ b/header_test.go
@@ -799,6 +799,30 @@ func TestParseMediaType(t *testing.T) {
 			mtype:  "text/html",
 			params: map[string]string{"name": "index;a.html", "hash": "8675309"},
 		},
+		{
+			label:  "with whitespace",
+			input:  "text/plain; charset=\"UTF-8\" ; format=flowed",
+			mtype:  "text/plain",
+			params: map[string]string{"charset": "UTF-8", "format": "flowed"},
+		},
+		{
+			label:  "with whitespace tab",
+			input:  "text/plain; charset=\"UTF-8\"\t; format=flowed",
+			mtype:  "text/plain",
+			params: map[string]string{"charset": "UTF-8", "format": "flowed"},
+		},
+		{
+			label:  "with newline and tab",
+			input:  "text/plain; charset=\"UTF-8\"\n\t; format=flowed",
+			mtype:  "text/plain",
+			params: map[string]string{"charset": "UTF-8", "format": "flowed"},
+		},
+		{
+			label:  "with newline and space",
+			input:  "application/pdf; name=foo\n ; format=flowed",
+			mtype:  "application/pdf",
+			params: map[string]string{"name": "foo", "format": "flowed"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.label, func(t *testing.T) {


### PR DESCRIPTION
This is a fix for the problem of PR: [193](https://github.com/jhillyerd/enmime/pull/193)

Sorry for taking over, but I really need the fix :(

Let me know if there is anything you would like me to change.

Thanks for the package.