### PR TITLE
Empty content type parameter ignored

### DIFF
--- a/header.go
+++ b/header.go
@@ -284,6 +284,11 @@ func fixMangledMediaType(mtype string, sep rune) string {
 				continue
 			}
 
+			if len(strings.TrimSpace(p)) == 0 {
+				// Ignore empty parameters.
+				continue
+			}
+
 			if !strings.Contains(p, "=") {
 				p = p + "=" + pvPlaceholder
 			}

--- a/header_test.go
+++ b/header_test.go
@@ -267,6 +267,11 @@ func TestFixMangledMediaType(t *testing.T) {
 			sep:   ';',
 			want:  `one/two; name="file.two"; iso-8859-1=` + pvPlaceholder,
 		},
+		{
+			input: `one/two; ; name="file.two"`,
+			sep:   ';',
+			want:  `one/two; name="file.two"`,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {


### PR DESCRIPTION
There are some emails which contain slighlty malformed Content-Type headers in form
```
Content-Type: application/x-pdf; ; name="=?utf-8?Q?PR-8469=5F2018.pdf?="
```
Function `fixMangledMediaType` turns such header to
```
Content-Type: application/x-pdf; =not-a-param-value; name="=?utf-8?Q?PR-8469=5F2018.pdf?="
```
This patch ignores empty parameter instead. According to RFC 1521 "the ordering of parameters is not significant" thus it should not harm anything.