### PR TITLE
Boundary reader - long lines processing fixed

### DIFF
--- a/boundary.go
+++ b/boundary.go
@@ -181,13 +181,18 @@ func (b *boundaryReader) Next() (bool, error) {
 		_, _ = io.Copy(ioutil.Discard, b)
 	}
 	for {
-		var line []byte
+		var line []byte = nil
 		var err error
 		for {
 			// Read whole line, handle extra long lines in cycle
 			var segment []byte
 			segment, err = b.r.ReadSlice('\n')
-			line = append(line, segment...)
+			if line == nil {
+				line = segment
+			} else {
+				line = append(line, segment...)
+			}
+
 			if err == nil || err == io.EOF {
 				break
 			} else if err != bufio.ErrBufferFull || len(segment) == 0 {

--- a/boundary_test.go
+++ b/boundary_test.go
@@ -477,6 +477,24 @@ func TestBoundaryReaderReadErrors(t *testing.T) {
 	}
 }
 
+func TestBoundaryReaderLongLine(t *testing.T) {
+	//dest := make([]byte, 8 *1024)
+	data := bytes.Repeat([]byte{1}, 7*1024)
+	data[6*1024] = '\n'
+
+	br := &boundaryReader{
+		r: bufio.NewReader(bytes.NewReader(data)),
+	}
+
+	next, err := br.Next()
+	if next {
+		t.Fatal("Next() should have returned false, failed")
+	}
+	if err != nil {
+		t.Fatal("Next() should have returned no error, failed")
+	}
+}
+
 // TestReadLenNotCap checks that the `boundaryReader` `io.Reader` implementation fills the provided
 // slice based on its length (as per the `io.Reader` documentation), and not its capacity.
 func TestReadLenNotCap(t *testing.T) {

--- a/boundary_test.go
+++ b/boundary_test.go
@@ -477,8 +477,8 @@ func TestBoundaryReaderReadErrors(t *testing.T) {
 	}
 }
 
+// TestBoundaryReaderLongLine checks that boundaryReader can read lines longer than the `peekBufferSize`.
 func TestBoundaryReaderLongLine(t *testing.T) {
-	//dest := make([]byte, 8 *1024)
 	data := bytes.Repeat([]byte{1}, 7*1024)
 	data[6*1024] = '\n'
 


### PR DESCRIPTION
Hi,

when there is a line longer than 4096 bytes, message parsing fails, because boundary reader returns bufio.ErrBufferFull.

This patch handles reading longer lines than 4096 bytes.