### PR TITLE
Fixed crash in QPCleaner, when line is too long and buffer is almost full

### DIFF
--- a/internal/coding/quotedprint.go
+++ b/internal/coding/quotedprint.go
@@ -84,6 +84,9 @@ func (qp *QPCleaner) Read(dest []byte) (n int, err error) {
 		if qp.lineLen >= MaxQPLineLen {
 			writeBytes(lineBreak)
 			qp.lineLen = 0
+			if n == destLen {
+				break
+			}
 		}
 
 		switch {

--- a/internal/coding/quotedprint_test.go
+++ b/internal/coding/quotedprint_test.go
@@ -137,6 +137,21 @@ func TestQPCleanerLineBreak(t *testing.T) {
 	}
 }
 
+func TestQPCleanerLineBreakBufferFull(t *testing.T) {
+	input := bytes.Repeat([]byte("abc"), 10000)
+	inbuf := bytes.NewBuffer(input)
+	qp := coding.NewQPCleaner(inbuf)
+
+	dest := make([]byte, 1025)
+	n, err := qp.Read(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1025 {
+		t.Errorf("Unexpected result length: %d", n)
+	}
+}
+
 var ErrPeek = errors.New("enmime test peek error")
 
 type peekBreakReader string


### PR DESCRIPTION
Hi,

there is a bug in new QPCleaner implementation, which causes panic. When the `qp.lineLen` exceeds `MaxQPLineLen`, newline is safely inserted to `dest` buffer. But it is not checked, if `n` is still `< destLen` after this insertion, causing write after the end of `dest` in the following `switch` statement.

Here is a fix and test, the test causes panic on current version, the checks are there just for completeness.

Best regards

Pavel