### PR TITLE
Fix newlines in mediatype.Parse

### DIFF
--- a/mediatype/mediatype.go
+++ b/mediatype/mediatype.go
@@ -39,9 +39,10 @@ const (
 //   * Missing ';' between content-type and media parameters
 //   * Repeating media parameters
 //   * Unquoted values in media parameters containing 'tspecials' characters
+//   * Newline characters
 func Parse(ctype string) (mtype string, params map[string]string, invalidParams []string, err error) {
 	mtype, params, err = mime.ParseMediaType(
-		fixUnescapedQuotes(fixUnquotedSpecials(fixMangledMediaType(ctype, ';'))))
+		fixNewlines(fixUnescapedQuotes(fixUnquotedSpecials(fixMangledMediaType(ctype, ';')))))
 	if err != nil {
 		if err.Error() == "mime: no media type" {
 			return "", nil, nil, nil
@@ -470,4 +471,11 @@ func fixUnescapedQuotes(hvalue string) string {
 	}
 
 	return sb.String()
+}
+
+// fixNewlines replaces \n with a space and removes \r
+func fixNewlines(value string) string {
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, "\r", "")
+	return value
 }

--- a/mediatype/mediatype_test.go
+++ b/mediatype/mediatype_test.go
@@ -458,6 +458,12 @@ func TestParseMediaType(t *testing.T) {
 			mtype:  "application/pdf",
 			params: map[string]string{"x-unix-mode": "0644", "name": "File name with spaces.pdf"},
 		},
+		{
+			label:  "Outlook-Logo with newlines",
+			input:  `application/octet-stream; name="=?utf-8?B?T3V0bG9vay1Mb2dvCgpEZXNj?="`,
+			mtype:  "application/octet-stream",
+			params: map[string]string{"name": "Outlook-Logo  Desc"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.label, func(t *testing.T) {


### PR DESCRIPTION
Added a very simple `fixNewlines` function to handle the following outlook produced case: 

```
		{
			label:  "Outlook-Logo with newlines",
			input:  `application/octet-stream; name="=?utf-8?B?T3V0bG9vay1Mb2dvCgpEZXNj?="`,
			mtype:  "application/octet-stream",
			params: map[string]string{"name": "Outlook-Logo  Desc"},
		},
```