### PR TITLE
fix(fixMangledMediaType) remove extra parts

### DIFF
--- a/mediatype/mediatype.go
+++ b/mediatype/mediatype.go
@@ -101,6 +101,11 @@ func fixMangledMediaType(mtype string, sep rune) string {
 					p = ctAppOctetStream
 				}
 			}
+			// Remove extra ctype parts
+			if strings.Count(p, "/") > 1 {
+				ps := strings.SplitN(p, "/", 3)
+				p = strings.Join(ps[0:2], "/")
+			}
 		default:
 			if len(p) == 0 {
 				// Ignore trailing separators.

--- a/mediatype/mediatype_test.go
+++ b/mediatype/mediatype_test.go
@@ -115,6 +115,18 @@ func TestFixMangledMediaType(t *testing.T) {
 			sep:   ';',
 			want:  `one/two; name="file.two"`,
 		},
+
+		// remove extra content type parts
+		{
+			input: `application/pdf/.pdf; name=1337.pdf`,
+			sep:   ';',
+			want:  `application/pdf; name=1337.pdf`,
+		},
+		{
+			input: `application/pdf/pdf/pdf; name=1337.pdf`,
+			sep:   ';',
+			want:  `application/pdf; name=1337.pdf`,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {


### PR DESCRIPTION
Hello,

I encountered some unknown email client in production. It used an invalid content type with extra parts, like `application/pdf/.pdf`

I `fixed` parsing by removing extra parts, but I'm not 100% sure it could be split as 
* `application` `pdf`
* `application` `pdf/.pdf`
* `application` `pdf-.pdf`

Thank you again for your great work