### PR TITLE
Remove <!DOCTYPE tag in bad content types

### DIFF
--- a/mediatype/mediatype.go
+++ b/mediatype/mediatype.go
@@ -42,7 +42,7 @@ const (
 //   * Newline characters
 func Parse(ctype string) (mtype string, params map[string]string, invalidParams []string, err error) {
 	mtype, params, err = mime.ParseMediaType(
-		fixNewlines(fixUnescapedQuotes(fixUnquotedSpecials(fixMangledMediaType(fixUnexpectedDoctype(ctype), ';')))))
+		fixNewlines(fixUnescapedQuotes(fixUnquotedSpecials(fixMangledMediaType(fixUnexpectedTag(ctype), ';')))))
 	if err != nil {
 		if err.Error() == "mime: no media type" {
 			return "", nil, nil, nil
@@ -485,9 +485,9 @@ func fixNewlines(value string) string {
 	return value
 }
 
-// fixUnexpectedDoctype removes an unexpected <!DOCTYPE tag
-func fixUnexpectedDoctype(value string) string {
-	dtIdx := strings.Index(value, "<!DOCTYPE")
+// fixUnexpectedTag removes an unexpected <!DOCTYPE tag
+func fixUnexpectedTag(value string) string {
+	dtIdx := strings.Index(value, "<")
 	if dtIdx > -1 {
 		return value[0:dtIdx]
 	}

--- a/mediatype/mediatype.go
+++ b/mediatype/mediatype.go
@@ -42,7 +42,7 @@ const (
 //   * Newline characters
 func Parse(ctype string) (mtype string, params map[string]string, invalidParams []string, err error) {
 	mtype, params, err = mime.ParseMediaType(
-		fixNewlines(fixUnescapedQuotes(fixUnquotedSpecials(fixMangledMediaType(ctype, ';')))))
+		fixNewlines(fixUnescapedQuotes(fixUnquotedSpecials(fixMangledMediaType(fixUnexpectedDoctype(ctype), ';')))))
 	if err != nil {
 		if err.Error() == "mime: no media type" {
 			return "", nil, nil, nil
@@ -482,5 +482,14 @@ func fixUnescapedQuotes(hvalue string) string {
 func fixNewlines(value string) string {
 	value = strings.ReplaceAll(value, "\n", " ")
 	value = strings.ReplaceAll(value, "\r", "")
+	return value
+}
+
+// fixUnexpectedDoctype removes an unexpected <!DOCTYPE tag
+func fixUnexpectedDoctype(value string) string {
+	dtIdx := strings.Index(value, "<!DOCTYPE")
+	if dtIdx > -1 {
+		return value[0:dtIdx]
+	}
 	return value
 }

--- a/mediatype/mediatype_test.go
+++ b/mediatype/mediatype_test.go
@@ -477,8 +477,14 @@ func TestParseMediaType(t *testing.T) {
 			params: map[string]string{"name": "Outlook-Logo  Desc"},
 		},
 		{
-			label:  "ignore doctype",
+			label:  "ignore tag",
 			input:  `text/html; charset="iso-8859-1"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">`,
+			mtype:  "text/html",
+			params: map[string]string{"charset": "iso-8859-1"},
+		},
+		{
+			label:  "ignore tag in string",
+			input:  `text/html; charset="iso-8859-1<!DOCTYPE ... ">"`,
 			mtype:  "text/html",
 			params: map[string]string{"charset": "iso-8859-1"},
 		},

--- a/mediatype/mediatype_test.go
+++ b/mediatype/mediatype_test.go
@@ -476,6 +476,12 @@ func TestParseMediaType(t *testing.T) {
 			mtype:  "application/octet-stream",
 			params: map[string]string{"name": "Outlook-Logo  Desc"},
 		},
+		{
+			label:  "ignore doctype",
+			input:  `text/html; charset="iso-8859-1"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">`,
+			mtype:  "text/html",
+			params: map[string]string{"charset": "iso-8859-1"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.label, func(t *testing.T) {


### PR DESCRIPTION
We came across a bad content type, which contained a doctype tag. This Change ignores it.