### PR TITLE
fix: fix for quote-printed utf-8 header with quotes

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -215,6 +215,6 @@ func ExampleEnvelope_GetHeaderKeys() {
 	// Mime-Version: 1.0
 	// Sender: André Pirard <PIRARD@vm1.ulg.ac.be>
 	// Subject: MIME UTF8 Test ¢ More Text
-	// To: Mirosław Marczak <marczak@inbucket.com>
+	// To: "Mirosław Marczak" <marczak@inbucket.com>
 	// User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0) Gecko/20121010 Thunderbird/16.0.1
 }

--- a/header.go
+++ b/header.go
@@ -78,7 +78,9 @@ var AddressHeaders = map[string]bool{
 // It is more tolerant of malformed headers than the ParseAddressList func provided in Go's net/mail
 // package.
 func ParseAddressList(list string) ([]*mail.Address, error) {
-	ret, err := mail.ParseAddressList(list)
+	parser := mail.AddressParser{WordDecoder: coding.NewExtMimeDecoder()}
+
+	ret, err := parser.ParseList(list)
 	if err != nil {
 		switch err.Error() {
 		case "mail: expected comma":

--- a/header.go
+++ b/header.go
@@ -90,6 +90,11 @@ func ParseAddressList(list string) ([]*mail.Address, error) {
 		return nil, err
 	}
 
+	for i := range ret {
+		// try to additionally decode Name with less strict decoder
+		ret[i].Name = coding.DecodeExtHeader(ret[i].Name)
+	}
+
 	return ret, nil
 }
 

--- a/header_test.go
+++ b/header_test.go
@@ -82,6 +82,13 @@ func TestParseAddressListResult(t *testing.T) {
 				Name:    "ze:Store Orange Premium Reseller",
 				Address: "noreply@mail.zestore.ru"}},
 		},
+		{
+			`"=?UTF-8?Q?Miros=C5=82aw_Marczak?=" <marczak@inbucket.com>`,
+			[]*mail.Address{{
+				Name:    "Mirosław Marczak",
+				Address: "marczak@inbucket.com",
+			}},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {

--- a/header_test.go
+++ b/header_test.go
@@ -89,6 +89,19 @@ func TestParseAddressListResult(t *testing.T) {
 				Address: "marczak@inbucket.com",
 			}},
 		},
+		{
+			`=?iso-8859-1?q?#=a3_c=a9_r=ae_u=b5?= <a@h>, =?big5?q?=a1=5d_=a1=61_=a1=71?= <b@h>`,
+			[]*mail.Address{
+				{
+					Name:    "#\u00a3 c\u00a9 r\u00ae u\u00b5",
+					Address: "a@h",
+				},
+				{
+					Name:    "\uff08 \uff5b \u3008",
+					Address: "b@h",
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {

--- a/internal/coding/headerext.go
+++ b/internal/coding/headerext.go
@@ -7,6 +7,13 @@ import (
 	"strings"
 )
 
+// NewExtMimeDecoder creates new MIME word decoder which allows decoding of additional charsets.
+func NewExtMimeDecoder() *mime.WordDecoder {
+	return &mime.WordDecoder{
+		CharsetReader: NewCharsetReader,
+	}
+}
+
 // DecodeExtHeader decodes a single line (per RFC 2047, aka Message Header Extensions) using Golang's
 // mime.WordDecoder.
 func DecodeExtHeader(input string) string {
@@ -15,9 +22,7 @@ func DecodeExtHeader(input string) string {
 		return input
 	}
 
-	dec := new(mime.WordDecoder)
-	dec.CharsetReader = NewCharsetReader
-	header, err := dec.DecodeHeader(input)
+	header, err := NewExtMimeDecoder().DecodeHeader(input)
 	if err != nil {
 		return input
 	}

--- a/testdata/mail/qp-utf8-header.raw
+++ b/testdata/mail/qp-utf8-header.raw
@@ -4,7 +4,7 @@ From: James Hillyerd <jamehi03@jamehi03lx.noa.com>, =?ISO-8859-1?Q?Andr=E9?= Pir
 Sender: =?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>
 User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0) Gecko/20121010 Thunderbird/16.0.1
 MIME-Version: 1.0
-To: =?UTF-8?Q?Miros=C5=82aw_Marczak?= <marczak@inbucket.com>
+To: "=?UTF-8?Q?Miros=C5=82aw_Marczak?=" <marczak@inbucket.com>
 Subject: =?utf-8?q?MIME_UTF8_Test_=c2=a2?= More Text
 Content-Type: multipart/alternative;
  boundary="------------020203040006070307010003"


### PR DESCRIPTION
This PR fixes decoding addresses with quotes. 
For example, `"=?UTF-8?Q?Miros=C5=82aw_Marczak?="` should be decoded as `Mirosław Marczak`.