### PR TITLE
fix: use extended parser after fixing address list

### DIFF
--- a/header.go
+++ b/header.go
@@ -85,7 +85,7 @@ func ParseAddressList(list string) ([]*mail.Address, error) {
 		switch err.Error() {
 		case "mail: expected comma":
 			// Attempt to add commas and parse again.
-			return mail.ParseAddressList(stringutil.EnsureCommaDelimitedAddresses(list))
+			return parser.ParseList(stringutil.EnsureCommaDelimitedAddresses(list))
 		case "mail: no address":
 			return nil, mail.ErrHeaderNotPresent
 		}

--- a/header_test.go
+++ b/header_test.go
@@ -102,6 +102,19 @@ func TestParseAddressListResult(t *testing.T) {
 				},
 			},
 		},
+		{
+			`=?big5?Q?ext-encoding-without-comma?= <ext-encoding-wo-comma@example.com> <other@example.com>`,
+			[]*mail.Address{
+				{
+					Name:    "ext-encoding-without-comma",
+					Address: "ext-encoding-wo-comma@example.com",
+				},
+				{
+					Name:    "",
+					Address: "other@example.com",
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {


### PR DESCRIPTION
Use extended parser for parsing "fixed" address list