### PR TITLE
Maximal number of errors recorded in Part limited

### DIFF
--- a/error.go
+++ b/error.go
@@ -25,6 +25,9 @@ const (
 	ErrorMissingRecipient = "no recipients (to, cc, bcc) set"
 )
 
+// MaxPartErrors limits number of part parsing errors, 0 means no limit.
+var MaxPartErrors = 1000
+
 // Error describes an error encountered while parsing.
 type Error struct {
 	Name   string // The name or type of error encountered, from Error consts.
@@ -48,22 +51,25 @@ func (e *Error) String() string {
 
 // addWarning builds a severe Error and appends to the Part error slice.
 func (p *Part) addError(name string, detailFmt string, args ...interface{}) {
-	p.Errors = append(
-		p.Errors,
-		&Error{
-			name,
-			fmt.Sprintf(detailFmt, args...),
-			true,
-		})
+	p.addProblem(&Error{
+		name,
+		fmt.Sprintf(detailFmt, args...),
+		true,
+	})
 }
 
 // addWarning builds a non-severe Error and appends to the Part error slice.
 func (p *Part) addWarning(name string, detailFmt string, args ...interface{}) {
-	p.Errors = append(
-		p.Errors,
-		&Error{
-			name,
-			fmt.Sprintf(detailFmt, args...),
-			false,
-		})
+	p.addProblem(&Error{
+		name,
+		fmt.Sprintf(detailFmt, args...),
+		false,
+	})
+}
+
+// addProblem adds general *Error to the Part error slice.
+func (p *Part) addProblem(err *Error) {
+	if (MaxPartErrors == 0) || (len(p.Errors) < MaxPartErrors) {
+		p.Errors = append(p.Errors, err)
+	}
 }

--- a/error.go
+++ b/error.go
@@ -25,8 +25,8 @@ const (
 	ErrorMissingRecipient = "no recipients (to, cc, bcc) set"
 )
 
-// MaxPartErrors limits number of part parsing errors, 0 means no limit.
-var MaxPartErrors = 1000
+// MaxPartErrors limits number of part parsing errors, errors after the limit are ignored. 0 means unlimited.
+var MaxPartErrors = 0
 
 // Error describes an error encountered while parsing.
 type Error struct {

--- a/error_test.go
+++ b/error_test.go
@@ -130,3 +130,42 @@ func TestErrorEnvelopeWarnings(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorLimit(t *testing.T) {
+	// Backup global variable
+	originalMaxPartErros := MaxPartErrors
+	defer func() {
+		MaxPartErrors = originalMaxPartErros
+	}()
+
+	addThreeErrors := func() int {
+		part := &Part{}
+		part.addError("test1", "test1")
+		part.addError("test2", "test2")
+		part.addError("test3", "test3")
+
+		return len(part.Errors)
+	}
+
+	// Check unlimited
+	var errCount int
+	MaxPartErrors = 0
+	errCount = addThreeErrors()
+	if errCount != 3 {
+		t.Errorf("Expected unlimited errors (3), got %d", errCount)
+	}
+
+	// Check limit
+	MaxPartErrors = 1
+	errCount = addThreeErrors()
+	if errCount != 1 {
+		t.Errorf("Expected limited errors (1), got %d", errCount)
+	}
+
+	// Check limit matching count
+	MaxPartErrors = 3
+	errCount = addThreeErrors()
+	if errCount != 3 {
+		t.Errorf("Expected limited errors (3), got %d", errCount)
+	}
+}

--- a/part.go
+++ b/part.go
@@ -309,11 +309,7 @@ func (p *Part) base64CorruptInputCheck(err error) error {
 	switch errors.Cause(err).(type) {
 	case base64.CorruptInputError:
 		p.Content = nil
-		p.Errors = append(p.Errors, &Error{
-			Name:   ErrorMalformedBase64,
-			Detail: err.Error(),
-			Severe: true,
-		})
+		p.addError(ErrorMalformedBase64, err.Error())
 		return nil
 	default:
 		return err


### PR DESCRIPTION
Hi,

I use enmime to parse emails in my service. It happened that instead of valid mime structure, client sent several MBs of base64 data as input. In such case, enmime consumes a lot of memory (several GBs). It's because `readHeader` function adds many many warnings in order to "Attempt to detect and repair a non-indented continuation of previous line" as comment says.

In the end, `readHeader` calls `ReadMIMEHeader`, which doesn't find valid MIME structure and fails with error and all these warnings are freed. However the memory peak remains and can lead to swapping.

To make it more robust, I'm adding a `MaxPartErrors` global public variable, which does not allow to record more than limit errors in one part. Default value is 1000 in my PR, but it can be also 0 if you desire, which means no limit and thus there will be no change in current behavior.

Best regards
Pavel

