### PR TITLE
fix: add decoding mail address

### DIFF
--- a/envelope_test.go
+++ b/envelope_test.go
@@ -803,6 +803,12 @@ Message body
 				{Name: "", Address: "other@company.com"},
 			},
 		},
+		{
+			`=?UTF-8?B?dGVzdG5hbWU=?= <=?UTF-8?B?dGVzdG5hbWU=?=@example.com>`,
+			[]*mail.Address{
+				{Name: "testname", Address: "testname@example.com"},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {

--- a/header.go
+++ b/header.go
@@ -93,8 +93,9 @@ func ParseAddressList(list string) ([]*mail.Address, error) {
 	}
 
 	for i := range ret {
-		// try to additionally decode Name with less strict decoder
+		// try to additionally decode with less strict decoder
 		ret[i].Name = coding.DecodeExtHeader(ret[i].Name)
+		ret[i].Address = coding.DecodeExtHeader(ret[i].Address)
 	}
 
 	return ret, nil

--- a/header_test.go
+++ b/header_test.go
@@ -115,6 +115,15 @@ func TestParseAddressListResult(t *testing.T) {
 				},
 			},
 		},
+		{
+			`=?UTF-8?B?dGVzdG5hbWU=?= <=?UTF-8?B?dGVzdG5hbWU=?=@example.com>`,
+			[]*mail.Address{
+				{
+					Name:    "testname",
+					Address: "testname@example.com",
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {


### PR DESCRIPTION
This commit adds additional decoding for encoded email address.
For example: `=?UTF-8?B?dGVzdG5hbWU=?=@example.com` -> `testname@example.com`