### PR TITLE
feat: add option skip malformed parts

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -137,9 +137,15 @@ func (e *Envelope) Clone() *Envelope {
 // provided reader into an Envelope, downconverting HTML to plain text if needed, and sorting the
 // attachments, inlines and other parts into their respective slices. Errors are collected from all
 // Parts and placed into the Envelope.Errors slice.
+// Uses default parser.
 func ReadEnvelope(r io.Reader) (*Envelope, error) {
+	return defaultParser.ReadEnvelope(r)
+}
+
+// ReadEnvelope is the same as ReadEnvelope, but respects configurations.
+func (p Parser) ReadEnvelope(r io.Reader) (*Envelope, error) {
 	// Read MIME parts from reader
-	root, err := ReadParts(r)
+	root, err := p.ReadParts(r)
 	if err != nil {
 		return nil, errors.WithMessage(err, "Failed to ReadParts")
 	}

--- a/error.go
+++ b/error.go
@@ -23,6 +23,8 @@ const (
 	ErrorCharsetDeclaration = "Character Set Declaration Mismatch"
 	// ErrorMissingRecipient name.
 	ErrorMissingRecipient = "no recipients (to, cc, bcc) set"
+	// ErrorMalformedChildPart name.
+	ErrorMalformedChildPart = "Malformed child part"
 )
 
 // MaxPartErrors limits number of part parsing errors, errors after the limit are ignored. 0 means unlimited.

--- a/options.go
+++ b/options.go
@@ -1,0 +1,17 @@
+package enmime
+
+// Option to configure parsing.
+type Option interface {
+	apply(p *Parser)
+}
+
+// SkipMalformedParts sets parsing to skip parts that's can't be parsed.
+func SkipMalformedParts() Option {
+	return skipMalformedPartsOption(true)
+}
+
+type skipMalformedPartsOption bool
+
+func (o skipMalformedPartsOption) apply(p *Parser) {
+	p.skipMalformedParts = bool(o)
+}

--- a/options.go
+++ b/options.go
@@ -6,8 +6,8 @@ type Option interface {
 }
 
 // SkipMalformedParts sets parsing to skip parts that's can't be parsed.
-func SkipMalformedParts() Option {
-	return skipMalformedPartsOption(true)
+func SkipMalformedParts(s bool) Option {
+	return skipMalformedPartsOption(s)
 }
 
 type skipMalformedPartsOption bool

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,21 @@
+package enmime
+
+// Parser parses MIME.
+// Default parser is a valid one.
+type Parser struct {
+	skipMalformedParts bool
+}
+
+// defaultParser is a Parser with default configuration.
+var defaultParser = Parser{}
+
+// NewParser creates new parser with given options.
+func NewParser(ops ...Option) *Parser {
+	p := Parser{}
+
+	for _, o := range ops {
+		o.apply(&p)
+	}
+
+	return &p
+}

--- a/part_test.go
+++ b/part_test.go
@@ -374,6 +374,57 @@ func TestMultiMixedParts(t *testing.T) {
 	test.ContentContainsString(t, p.Content, want)
 }
 
+func TestMultiSkipMalformedPart(t *testing.T) {
+	var want string
+	var wantp *enmime.Part
+	r := test.OpenTestData("parts", "multi-malformed.raw")
+	parser := enmime.NewParser(enmime.SkipMalformedParts())
+	p, err := parser.ReadParts(r)
+
+	// Examine root
+	if err != nil {
+		t.Fatalf("Unexpected parse error: %+v", err)
+	}
+	if p == nil {
+		t.Fatal("Root node should not be nil")
+	}
+
+	wantp = &enmime.Part{
+		FirstChild:  test.PartExists,
+		ContentType: "multipart/mixed",
+		PartID:      "0",
+	}
+	test.ComparePart(t, p, wantp)
+
+	test.ContentEqualsString(t, p.Content, "")
+
+	// Examine first child
+	p = p.FirstChild
+	wantp = &enmime.Part{
+		Parent:      test.PartExists,
+		NextSibling: test.PartExists,
+		ContentType: "text/plain",
+		Charset:     "us-ascii",
+		PartID:      "1",
+	}
+	test.ComparePart(t, p, wantp)
+
+	want = "Section one"
+	test.ContentContainsString(t, p.Content, want)
+
+	// Examine sibling
+	p = p.NextSibling
+	wantp = &enmime.Part{
+		Parent:      test.PartExists,
+		ContentType: "text/plain",
+		Charset:     "us-ascii",
+		PartID:      "3",
+	}
+	test.ComparePart(t, p, wantp)
+
+	want = "Section two"
+}
+
 func TestMultiOtherParts(t *testing.T) {
 	var want string
 	var wantp *enmime.Part

--- a/part_test.go
+++ b/part_test.go
@@ -412,7 +412,7 @@ func TestMultiSkipMalformedPart(t *testing.T) {
 	want = "Section one"
 	test.ContentContainsString(t, p.Content, want)
 
-	// Examine sibling
+	// Verify sibling is Section two and not the malformed part.
 	p = p.NextSibling
 	wantp = &enmime.Part{
 		Parent:      test.PartExists,

--- a/part_test.go
+++ b/part_test.go
@@ -379,7 +379,7 @@ func TestMultiSkipMalformedPart(t *testing.T) {
 	var want string
 	var wantp *enmime.Part
 	r := test.OpenTestData("parts", "multi-malformed.raw")
-	parser := enmime.NewParser(enmime.SkipMalformedParts())
+	parser := enmime.NewParser(enmime.SkipMalformedParts(true))
 	p, err := parser.ReadParts(r)
 
 	// Examine root
@@ -428,7 +428,7 @@ func TestMultiSkipMalformedPart(t *testing.T) {
 
 func TestMultiNoSkipMalformedPartFails(t *testing.T) {
 	r := test.OpenTestData("parts", "multi-malformed.raw")
-	parser := enmime.NewParser()
+	parser := enmime.NewParser(enmime.SkipMalformedParts(false))
 	_, err := parser.ReadParts(r)
 	if err == nil {
 		t.Fatal("Expecting parsing to fail")

--- a/part_test.go
+++ b/part_test.go
@@ -1,6 +1,7 @@
 package enmime_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/jhillyerd/enmime"
@@ -423,6 +424,19 @@ func TestMultiSkipMalformedPart(t *testing.T) {
 	test.ComparePart(t, p, wantp)
 
 	want = "Section two"
+}
+
+func TestMultiNoSkipMalformedPartFails(t *testing.T) {
+	r := test.OpenTestData("parts", "multi-malformed.raw")
+	parser := enmime.NewParser()
+	_, err := parser.ReadParts(r)
+	if err == nil {
+		t.Fatal("Expecting parsing to fail")
+	}
+
+	if !strings.Contains(err.Error(), "malformed MIME header initial line") {
+		t.Fatal("Expecting for error to contain \"malformed MIME header\" error")
+	}
 }
 
 func TestMultiOtherParts(t *testing.T) {

--- a/testdata/parts/multi-malformed.raw
+++ b/testdata/parts/multi-malformed.raw
@@ -1,0 +1,19 @@
+Content-Type: multipart/mixed; boundary="Enmime-Test-100"
+
+--Enmime-Test-100
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain; charset=us-ascii
+
+Section one
+
+--Enmime-Test-100
+I'm section without headers
+
+--Enmime-Test-100
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain; charset=us-ascii
+
+Section two
+
+--Enmime-Test-100--
+


### PR DESCRIPTION
This PR is proposal for the feature which allows to skip parts that can't be parsed. It won't return error, just add them to "problems"

This can be useful if you need to parse everything what is possible to parse and turned off by default.

For example, we have emails which have body of the email starting at the beginning of the part (without headers). Currently parser returns error,  but it can be beneficial to skip this part.

```
...
Content-Type: multipart/report; report-type=delivery-status;
	boundary="12345/example.com"
Auto-Submitted: auto-generated (failure)
MIME-Version: 1.0

--12345/example.com
[EXTERNAL EMAIL]

The original message was received
...
```