### PR TITLE
fix: buffer overrun when quoted printable is at the end of line and output buffer

### DIFF
--- a/internal/coding/quotedprint_test.go
+++ b/internal/coding/quotedprint_test.go
@@ -148,7 +148,7 @@ func TestQPCleanerLineBreakBufferFull(t *testing.T) {
 		t.Fatal(err)
 	}
 	if n != 1025 {
-		t.Errorf("Unexpected result length: %d", n)
+		t.Error("got:", n, "want:", 1025)
 	}
 }
 
@@ -167,10 +167,10 @@ func TestQPCleanerEqualSignOverflow(t *testing.T) {
 		t.Fatal(err)
 	}
 	if n != 1024 {
-		t.Errorf("Unexpected result length: %d", n)
+		t.Error("got:", n, "want:", 1024)
 	}
 	if string(output[1020:]) != "abc=" {
-		t.Errorf("Unexpected result content: %s", output[1020:])
+		t.Error("got:", string(output[1020:]), "want:", "abc=")
 	}
 
 	n, err = qp.Read(output)
@@ -178,11 +178,11 @@ func TestQPCleanerEqualSignOverflow(t *testing.T) {
 		t.Fatal(err)
 	}
 	if n != 5 {
-		t.Errorf("Unexpected result length: %d", n)
+		t.Error("got:", n, "want:", 5)
 	}
 	output = output[:n]
 	if string(output) != "\r\n=3D" {
-		t.Errorf("Unexpected result content: %s", string(output))
+		t.Error("got:", string(output), "want:", "\r\n=3D")
 	}
 }
 


### PR DESCRIPTION
In QPCleaner, write behind the buffer end could occur, when there was a `=XX` quoted printable token, line length was 1023 and remaining dest buffer space was only 1 byte. Because of line length, QPCleaner inserted `=\r\n`, but only the equal sign fit into the output buffer. The rest went to qp.overflow. 

Then the algorithm wrote to `dest[n]` without any additional checks, but `n` already pointed behind the buffer end.

Now the equal sign is also written to overflow in such situation.

I've also noticed, that qp.lineLength is not incremented when qp.overflow is put at the beginning of new buffer and also when `=` from quoted printable token is inserted. Seems as a bug to me, but I don't fix it in this PR.