### PR TITLE
fix: QPCleaner line length equal sign counting

### DIFF
--- a/internal/coding/quotedprint.go
+++ b/internal/coding/quotedprint.go
@@ -52,7 +52,7 @@ func (qp *QPCleaner) Read(dest []byte) (n int, err error) {
 		qp.lineLen++
 	}
 
-	// safeWriteByte outputs a signle byte, storing overflow for next read. Updates counters.
+	// safeWriteByte outputs a single byte, storing overflow for next read. Updates counters.
 	safeWriteByte := func(in byte) {
 		if n < destLen {
 			dest[n] = in
@@ -60,6 +60,7 @@ func (qp *QPCleaner) Read(dest []byte) (n int, err error) {
 		} else {
 			qp.overflow = append(qp.overflow, in)
 		}
+		qp.lineLen++
 	}
 
 	// writeBytes outputs multiple bytes, storing overflow for next read. Updates counters.

--- a/internal/coding/quotedprint_test.go
+++ b/internal/coding/quotedprint_test.go
@@ -205,6 +205,39 @@ func TestQPPeekError(t *testing.T) {
 	}
 }
 
+func TestQPCleanerQuotedLineLength(t *testing.T) {
+	input := strings.Repeat("=BC", 700) // ~ two lines of token
+	inr := strings.NewReader(input)
+	qp := coding.NewQPCleaner(inr)
+
+	// Check line length is counted proerly even for quoted printable encoded chars
+	longLineLen := coding.MaxQPLineLen + 2
+	output := make([]byte, longLineLen)
+	n, err := qp.Read(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != longLineLen {
+		t.Error("got:", n, "want:", longLineLen)
+	}
+	if string(output[longLineLen-2:]) != "\r\n" {
+		t.Error("got:", string(output[longLineLen-2:]), "want:", "\r\n")
+	}
+
+	// Check line length is correct also when overflow buffer of QPCleaner is used
+	output = make([]byte, longLineLen)
+	n, err = qp.Read(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != longLineLen {
+		t.Error("got:", n, "want:", longLineLen)
+	}
+	if string(output[longLineLen-2:]) != "\r\n" {
+		t.Error("got:", string(output[longLineLen-2:]), "want:", "\r\n")
+	}
+}
+
 var result int
 
 func BenchmarkQPCleaner(b *testing.B) {


### PR DESCRIPTION
Hi,

as mentioned in https://github.com/jhillyerd/enmime/pull/254, this fixes missing counting of `=` when quoted printable encoded char is processed.

I've also mentioned, that line length is not incremented, when `qp.overflow` is put into the buffer at the beginning of the next `Read`. Tests show it is not needed, because `qp.lineLength` is set, when `qp.overflow` is filled at the end of previous `Read`.

Regards