### PR TITLE
feat: add option to treat multipart w/o boundary as single-part

### DIFF
--- a/detect_test.go
+++ b/detect_test.go
@@ -14,7 +14,7 @@ func TestDetectSinglePart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if detectMultipartMessage(msg) {
+	if detectMultipartMessage(msg, false) {
 		t.Error("Failed to identify non-multipart message")
 	}
 }
@@ -26,7 +26,7 @@ func TestDetectMultiPart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !detectMultipartMessage(msg) {
+	if !detectMultipartMessage(msg, false) {
 		t.Error("Failed to identify multipart MIME message")
 	}
 }
@@ -38,8 +38,24 @@ func TestDetectUnknownMultiPart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !detectMultipartMessage(msg) {
+	if !detectMultipartMessage(msg, false) {
 		t.Error("Failed to identify multipart MIME message of unknown type")
+	}
+}
+
+func TestDetectMultipartWithoutBoundary(t *testing.T) {
+	r, _ := os.Open(filepath.Join("testdata", "mail", "multipart-wo-boundary.raw"))
+	msg, err := ReadParts(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !detectMultipartMessage(msg, false) {
+		t.Error("Failed to identify multipart MIME message")
+	}
+
+	if detectMultipartMessage(msg, true) {
+		t.Error("Failed to identify multipart MIME message without boundaries as single-part")
 	}
 }
 

--- a/envelope.go
+++ b/envelope.go
@@ -176,7 +176,7 @@ func (p Parser) EnvelopeFromPart(root *Part) (*Envelope, error) {
 		header: &root.Header,
 	}
 
-	if detectMultipartMessage(root, p.multipartWOBoundaryAsSinglepart) {
+	if detectMultipartMessage(root, p.multipartWOBoundaryAsSinglePart) {
 		// Multi-part message (message with attachments, etc)
 		if err := parseMultiPartBody(root, e); err != nil {
 			return nil, err

--- a/envelope.go
+++ b/envelope.go
@@ -152,26 +152,31 @@ func ReadEnvelope(r io.Reader) (*Envelope, error) {
 	return defaultParser.ReadEnvelope(r)
 }
 
-// ReadEnvelope is the same as ReadEnvelope, but respects configurations.
+// ReadEnvelope is the same as ReadEnvelope, but respects parser configurations.
 func (p Parser) ReadEnvelope(r io.Reader) (*Envelope, error) {
 	// Read MIME parts from reader
 	root, err := p.ReadParts(r)
 	if err != nil {
 		return nil, errors.WithMessage(err, "Failed to ReadParts")
 	}
-	return EnvelopeFromPart(root)
+	return p.EnvelopeFromPart(root)
 }
 
 // EnvelopeFromPart uses the provided Part tree to build an Envelope, downconverting HTML to plain
 // text if needed, and sorting the attachments, inlines and other parts into their respective
 // slices.  Errors are collected from all Parts and placed into the Envelopes Errors slice.
 func EnvelopeFromPart(root *Part) (*Envelope, error) {
+	return defaultParser.EnvelopeFromPart(root)
+}
+
+// EnvelopeFromPart is the same as EnvelopeFromPart, but respects parser configurations.
+func (p Parser) EnvelopeFromPart(root *Part) (*Envelope, error) {
 	e := &Envelope{
 		Root:   root,
 		header: &root.Header,
 	}
 
-	if detectMultipartMessage(root) {
+	if detectMultipartMessage(root, p.multipartWOBoundaryAsSinglepart) {
 		// Multi-part message (message with attachments, etc)
 		if err := parseMultiPartBody(root, e); err != nil {
 			return nil, err

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -589,6 +589,31 @@ func TestParseHTMLOnlyCharsetInHeaderOnly(t *testing.T) {
 	}
 }
 
+func TestParseMultipartWOBoundaryFails(t *testing.T) {
+	r := test.OpenTestData("mail", "multipart-wo-boundary.raw")
+	_, err := enmime.ReadEnvelope(r)
+	if err == nil {
+		t.Fatal("Expecting parsing to fail")
+	}
+
+	if !strings.Contains(err.Error(), "unable to locate boundary param in Content-Type header") {
+		t.Fatal("Expecting for unable to locate boundary error")
+	}
+}
+
+func TestParseMultipartWOBoundaryAsSinglepart(t *testing.T) {
+	r := test.OpenTestData("mail", "multipart-wo-boundary.raw")
+	p := enmime.NewParser(enmime.MultipartWOBoundaryAsSinglepart(true))
+	e, err := p.ReadEnvelope(r)
+	if err != nil {
+		t.Fatal("Failed to parse MIME:", err)
+	}
+
+	if !bytes.Contains(e.Root.Content, []byte(`I'm  multipart message without boundary`)) {
+		t.Fatal("Expecting multipart without boundary to be parsed")
+	}
+}
+
 func TestEnvelopeGetHeader(t *testing.T) {
 	// Test empty header
 	e := &enmime.Envelope{}

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -603,7 +603,7 @@ func TestParseMultipartWOBoundaryFails(t *testing.T) {
 
 func TestParseMultipartWOBoundaryAsSinglepart(t *testing.T) {
 	r := test.OpenTestData("mail", "multipart-wo-boundary.raw")
-	p := enmime.NewParser(enmime.MultipartWOBoundaryAsSinglepart(true))
+	p := enmime.NewParser(enmime.MultipartWOBoundaryAsSinglePart(true))
 	e, err := p.ReadEnvelope(r)
 	if err != nil {
 		t.Fatal("Failed to parse MIME:", err)

--- a/options.go
+++ b/options.go
@@ -16,14 +16,14 @@ func (o skipMalformedPartsOption) apply(p *Parser) {
 	p.skipMalformedParts = bool(o)
 }
 
-// MultipartWOBoundaryAsSinglepart if set to true will treat a multi-part messages without boundary parameter as single-part.
+// MultipartWOBoundaryAsSinglePart if set to true will treat a multi-part messages without boundary parameter as single-part.
 // Otherwise, will return error that boundary is not found.
-func MultipartWOBoundaryAsSinglepart(a bool) Option {
-	return multipartWOBoundaryAsSinglepartOption(a)
+func MultipartWOBoundaryAsSinglePart(a bool) Option {
+	return multipartWOBoundaryAsSinglePartOption(a)
 }
 
-type multipartWOBoundaryAsSinglepartOption bool
+type multipartWOBoundaryAsSinglePartOption bool
 
-func (o multipartWOBoundaryAsSinglepartOption) apply(p *Parser) {
-	p.multipartWOBoundaryAsSinglepart = bool(o)
+func (o multipartWOBoundaryAsSinglePartOption) apply(p *Parser) {
+	p.multipartWOBoundaryAsSinglePart = bool(o)
 }

--- a/options.go
+++ b/options.go
@@ -15,3 +15,15 @@ type skipMalformedPartsOption bool
 func (o skipMalformedPartsOption) apply(p *Parser) {
 	p.skipMalformedParts = bool(o)
 }
+
+// MultipartWOBoundaryAsSinglepart if set to true will treat a multi-part messages without boundary parameter as single-part.
+// Otherwise, will return error that boundary is not found.
+func MultipartWOBoundaryAsSinglepart(a bool) Option {
+	return multipartWOBoundaryAsSinglepartOption(a)
+}
+
+type multipartWOBoundaryAsSinglepartOption bool
+
+func (o multipartWOBoundaryAsSinglepartOption) apply(p *Parser) {
+	p.multipartWOBoundaryAsSinglepart = bool(o)
+}

--- a/parser.go
+++ b/parser.go
@@ -4,7 +4,7 @@ package enmime
 // Default parser is a valid one.
 type Parser struct {
 	skipMalformedParts              bool
-	multipartWOBoundaryAsSinglepart bool
+	multipartWOBoundaryAsSinglePart bool
 }
 
 // defaultParser is a Parser with default configuration.

--- a/parser.go
+++ b/parser.go
@@ -3,7 +3,8 @@ package enmime
 // Parser parses MIME.
 // Default parser is a valid one.
 type Parser struct {
-	skipMalformedParts bool
+	skipMalformedParts              bool
+	multipartWOBoundaryAsSinglepart bool
 }
 
 // defaultParser is a Parser with default configuration.

--- a/part.go
+++ b/part.go
@@ -356,7 +356,8 @@ func (p Parser) ReadParts(r io.Reader) (*Part, error) {
 	if err != nil {
 		return nil, err
 	}
-	if strings.HasPrefix(root.ContentType, ctMultipartPrefix) {
+
+	if detectMultipartMessage(root, p.multipartWOBoundaryAsSinglepart) {
 		// Content is multipart, parse it.
 		err = parseParts(root, br, p.skipMalformedParts)
 		if err != nil {

--- a/part.go
+++ b/part.go
@@ -357,7 +357,7 @@ func (p Parser) ReadParts(r io.Reader) (*Part, error) {
 		return nil, err
 	}
 
-	if detectMultipartMessage(root, p.multipartWOBoundaryAsSinglepart) {
+	if detectMultipartMessage(root, p.multipartWOBoundaryAsSinglePart) {
 		// Content is multipart, parse it.
 		err = parseParts(root, br, p.skipMalformedParts)
 		if err != nil {

--- a/testdata/mail/multipart-wo-boundary.raw
+++ b/testdata/mail/multipart-wo-boundary.raw
@@ -1,0 +1,8 @@
+Delivered-To: test@example.com
+From: Mailer-Daemon@example.com
+Subject: Delivery Status Notification (Failure)
+To: user@example.com
+Content-Type: multipart/report;
+Message-Id: <444A6F676F-A9A1C1F7-799A-4D89-B97E-8057E132FBFB@YSHSERVER>
+
+I'm  multipart message without boundary


### PR DESCRIPTION
Thit PR is a proposal to add option to treat multipart message without boundary as single-part.

For example message:
```
Content-Type: multipart/report;

I'm  multipart message without boundary
```

doesn't have boundary parameter in `Content-Type` header, but still can be parsed as single-part message.
Currently, parser returns error that it can't find boundary. With option turned on, parser will treat multipart messages without boundary as single-part.