### PR TITLE
fix: Reject invalid MIME header name characters to support Go 1.20

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,15 +8,15 @@ jobs:
       matrix:
         go:
           - 1.16.x
-          - 1.17.x
           - 1.18.x
+          - 1.20.0-rc.2
     name: Go ${{ matrix.go }} build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Build and Test

--- a/header_test.go
+++ b/header_test.go
@@ -247,9 +247,9 @@ func TestReadHeader(t *testing.T) {
 		{
 			label:   "equals in name",
 			input:   "name=value:text\n",
-			hname:   "name=value",
-			want:    "text",
-			correct: true,
+			hname:   "",
+			want:    "",
+			correct: false,
 		},
 		{
 			label:   "no space before continuation",
@@ -354,6 +354,11 @@ func TestReadHeader(t *testing.T) {
 			gotErrs := len(p.Errors)
 			if gotErrs != wantErrs {
 				t.Errorf("Got %v p.Errors, want %v", gotErrs, wantErrs)
+				if gotErrs > 0 {
+					for _, e := range p.Errors {
+						t.Log(e)
+					}
+				}
 			}
 
 			// Check for extra headers by removing expected ones.

--- a/header_test.go
+++ b/header_test.go
@@ -217,8 +217,6 @@ func TestReadHeader(t *testing.T) {
 		{
 			label:   "missing name",
 			input:   ": line1=foo\r\n",
-			hname:   "",
-			want:    "",
 			correct: false,
 		},
 		{
@@ -245,10 +243,15 @@ func TestReadHeader(t *testing.T) {
 			correct: true,
 		},
 		{
+			label:   "permitted specials in name",
+			input:   "Begin!#$%&'*+-.^_`|~End: text\n",
+			hname:   "Begin!#$%&'*+-.^_`|~End",
+			want:    "text",
+			correct: true,
+		},
+		{
 			label:   "equals in name",
 			input:   "name=value:text\n",
-			hname:   "",
-			want:    "",
 			correct: false,
 		},
 		{


### PR DESCRIPTION
Fixes #269
