### PR TITLE
feat: export DecodeRFC2047 (#277)

### DIFF
--- a/inspect.go
+++ b/inspect.go
@@ -20,6 +20,13 @@ var defaultHeadersList = []string{
 	"Date",
 }
 
+// DecodeRFC2047 decodes the given string according to RFC 2047 and returns the
+// decoded UTF-8 equivalent. If the input is not using RFC 2047 encoding, or the
+// charset is not recognized, it will return the input unmodified.
+func DecodeRFC2047(s string) string {
+	return coding.RFC2047Decode(s)
+}
+
 // DecodeHeaders returns a limited selection of mime headers for use by user agents
 // Default header list:
 //
@@ -45,7 +52,7 @@ func DecodeHeaders(b []byte, addtlHeaders ...string) (textproto.MIMEHeader, erro
 		h := textproto.CanonicalMIMEHeaderKey(header)
 		res[h] = make([]string, 0, len(headers[h]))
 		for _, value := range headers[h] {
-			res[h] = append(res[h], coding.RFC2047Decode(value))
+			res[h] = append(res[h], DecodeRFC2047(value))
 		}
 	}
 

--- a/inspect_test.go
+++ b/inspect_test.go
@@ -13,6 +13,29 @@ import (
 	"github.com/jhillyerd/enmime/internal/test"
 )
 
+func TestDecodeRFC2047(t *testing.T) {
+	t.Run("rfc2047 basic", func(t *testing.T) {
+		s := enmime.DecodeRFC2047("=?UTF-8?Q?Miros=C5=82aw_Marczak?=")
+		if s != "Mirosław Marczak" {
+			t.Errorf("Wrong decoded result")
+		}
+	})
+
+	t.Run("rfc2047 unknown", func(t *testing.T) {
+		s := enmime.DecodeRFC2047("=?ABC-1?Q?FooBar?=")
+		if s != "=?ABC-1?Q?FooBar?=" {
+			t.Errorf("Expected unmodified result for unknown charset")
+		}
+	})
+
+	t.Run("rfc2047 pass-through", func(t *testing.T) {
+		s := enmime.DecodeRFC2047("Hello World")
+		if s != "Hello World" {
+			t.Errorf("Expected unmodified result")
+		}
+	})
+}
+
 func TestDecodeHeaders(t *testing.T) {
 	t.Run("rfc2047 sample", func(t *testing.T) {
 		r := test.OpenTestData("mail", "qp-utf8-header.raw")


### PR DESCRIPTION
Exports coding.RFC2047Decode(), making the large set of charsets more readily available for package users.