### PR TITLE
Read all part content use ReadPartErrorPolicy.

### DIFF
--- a/part.go
+++ b/part.go
@@ -301,7 +301,7 @@ func (p *Part) decodeContent(r io.Reader, readPartErrorPolicy ReadPartErrorPolic
 		}
 	}
 	// Decode and store content.
-	content, err := ioutil.ReadAll(contentReader)
+	content, err := p.readPartContent(contentReader, readPartErrorPolicy)
 	if err != nil {
 		return p.base64CorruptInputCheck(errors.WithStack(err))
 	}


### PR DESCRIPTION
Hi,
    
The `ReadPartErrorPolicy` only used by content type `text/*`,  Wouldn't it be better to use ReadPartErrorPolicy to control known errors when reading all part content?

For example, if the content type is `image/*`, a `base64.CorruptInputError` occurs while reading part content. This image may also be displayed if this error is ignored.