### PR TITLE
feat: add support for multiple Reply-To addresses

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -348,6 +348,12 @@ func TestBuilderReplyTo(t *testing.T) {
 		t.Error("Same ReplyTo(value) should be equal")
 	}
 
+	if !reflect.DeepEqual(a.GetReplyTo(), b.GetReplyTo()) {
+		t.Error("Same GetReplyTo() should be equal")
+	} else if len(a.GetReplyTo()) == 0 {
+		t.Error("GetReplyTo() shouldn't be empty")
+	}
+
 	a = enmime.Builder().ReplyTo("name", "foo")
 	b = enmime.Builder().ReplyTo("name", "bar")
 	if a.Equals(b) {
@@ -360,6 +366,12 @@ func TestBuilderReplyTo(t *testing.T) {
 		t.Error("ReplyTo() should not mutate receiver, failed")
 	}
 
+	a = enmime.Builder().ReplyToAddrs([]mail.Address{{Name: "name", Address: "foo"}})
+	b = a.ReplyToAddrs([]mail.Address{{Name: "name", Address: "bar"}})
+	if a.Equals(b) {
+		t.Error("ReplyToAddrs() should not mutate receiver, failed")
+	}
+
 	a = enmime.Builder().ToAddrs(addrSlice).From("name", "foo").Subject("foo")
 	a = a.ReplyTo("one", "one@inbucket.org")
 	want := "\"one\" <one@inbucket.org>"
@@ -368,6 +380,21 @@ func TestBuilderReplyTo(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := p.Header.Get("Reply-To")
+	if got != want {
+		t.Errorf("Reply-To: %q, want: %q", got, want)
+	}
+
+	input := []mail.Address{
+		{Name: "one", Address: "one@inbucket.org"},
+		{Name: "two", Address: "two@inbucket.org"},
+	}
+	a = enmime.Builder().ReplyToAddrs(input).ToAddrs(input).From("name", "foo").Subject("foo")
+	want = "\"one\" <one@inbucket.org>, \"two\" <two@inbucket.org>"
+	p, err = a.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = p.Header.Get("Reply-To")
 	if got != want {
 		t.Errorf("Reply-To: %q, want: %q", got, want)
 	}


### PR DESCRIPTION
Hello @jhillyerd and enmime maintainers,

I've been working on a feature enhancement for the enmime library to add support for multiple reply-to addresses, as described in RFC 5322, section 3.6.2. I believe this functionality will improve the flexibility of the library and provide users with the ability to correctly handle multiple reply-to addresses as per the email specification.

Here is a brief overview of the changes I've made in this commit:

- Updated the ``MailBuilder`` struct to store multiple reply-to addresses.
- Modified the ``Build`` function to correctly write multiple reply-to addresses.
- Updated the ``GetReplyTo`` function to return the first email in the list for backward compatibility, and added a new ``GetReplyToAddrs`` function to return a slice copy of all addresses.
- Updated the existing ``ReplyTo`` function to support backward compatibility by handling single email addresses while using the new reply-to address list, and added a new ``ReplyToAddrs`` function to support setting the whole reply-to list.
- Added new tests to validate the proper handling of multiple reply-to addresses.

Thank you for your time and consideration. I'm looking forward to your feedback and the opportunity to contribute to this project.