### PR TITLE
fix for values with encoded equal signs

### DIFF
--- a/internal/coding/headerext.go
+++ b/internal/coding/headerext.go
@@ -54,20 +54,20 @@ func RFC2047Decode(s string) string {
 
 		default:
 			if decoded {
-				keyValuePair := strings.SplitAfterN(s, "=", 2)
-				if len(keyValuePair) < 2 {
+				key, value, found := strings.Cut(s, "=")
+				if !found {
 					return s
 				}
 
 				// Add quotes as needed.
-				if !strings.HasPrefix(keyValuePair[1], "\"") {
-					keyValuePair[1] = fmt.Sprintf("\"%s", keyValuePair[1])
+				if !strings.HasPrefix(value, "\"") {
+					value = fmt.Sprintf("\"%s", value)
 				}
-				if !strings.HasSuffix(keyValuePair[1], "\"") {
-					keyValuePair[1] = fmt.Sprintf("%s\"", keyValuePair[1])
+				if !strings.HasSuffix(value, "\"") {
+					value = fmt.Sprintf("%s\"", value)
 				}
 
-				return strings.Join(keyValuePair, "")
+				return fmt.Sprintf("%s=%s", key, value)
 			}
 
 			return s

--- a/internal/coding/headerext.go
+++ b/internal/coding/headerext.go
@@ -54,7 +54,7 @@ func RFC2047Decode(s string) string {
 
 		default:
 			if decoded {
-				keyValuePair := strings.SplitAfter(s, "=")
+				keyValuePair := strings.SplitAfterN(s, "=", 2)
 				if len(keyValuePair) < 2 {
 					return s
 				}

--- a/mediatype/mediatype_test.go
+++ b/mediatype/mediatype_test.go
@@ -497,6 +497,12 @@ func TestParseMediaType(t *testing.T) {
 			mtype:  "multipart/alternative",
 			params: map[string]string{"boundary": "<myboundary>"},
 		},
+		{
+			label:  "encoded equal sign",
+			input:  "application/pdf; name=\"=?iso-8859-1?Q?key=3Dvalue?=\"",
+			mtype:  "application/pdf",
+			params: map[string]string{"name": "key=value"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.label, func(t *testing.T) {


### PR DESCRIPTION
We faced the issue that emails with encoded equal signs could not be parsed in certain cases. This fix should improve the situation. 
Thank you in advance for any code reviews and great library!