### PR TITLE
MIMEHeader: use Go's net/textproto for public interface

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -7,13 +7,13 @@ import (
 	"math/rand"
 	"mime"
 	"net/mail"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"reflect"
 	"time"
 
 	"github.com/jhillyerd/enmime/internal/stringutil"
-	"github.com/jhillyerd/enmime/internal/textproto"
 )
 
 // MailBuilder facilitates the easy construction of a MIME message.  Each manipulation method

--- a/detect.go
+++ b/detect.go
@@ -3,7 +3,7 @@ package enmime
 import (
 	"strings"
 
-	"github.com/jhillyerd/enmime/internal/textproto"
+	inttp "github.com/jhillyerd/enmime/internal/textproto"
 	"github.com/jhillyerd/enmime/mediatype"
 )
 
@@ -35,7 +35,7 @@ func detectMultipartMessage(root *Part, multipartWOBoundaryAsSinglepart bool) bo
 //   - Content-Disposition: attachment; filename="frog.jpg"
 //   - Content-Disposition: inline; filename="frog.jpg"
 //   - Content-Type: attachment; filename="frog.jpg"
-func detectAttachmentHeader(header textproto.MIMEHeader) bool {
+func detectAttachmentHeader(header inttp.MIMEHeader) bool {
 	mtype, params, _, _ := mediatype.Parse(header.Get(hnContentDisposition))
 	if strings.ToLower(mtype) == cdAttachment ||
 		(strings.ToLower(mtype) == cdInline && len(params) > 0) {
@@ -49,7 +49,7 @@ func detectAttachmentHeader(header textproto.MIMEHeader) bool {
 // detectTextHeader returns true, if the the MIME headers define a valid 'text/plain' or 'text/html'
 // part.  If the emptyContentTypeIsPlain argument is set to true, a missing Content-Type header will
 // result in a positive plain part detection.
-func detectTextHeader(header textproto.MIMEHeader, emptyContentTypeIsText bool) bool {
+func detectTextHeader(header inttp.MIMEHeader, emptyContentTypeIsText bool) bool {
 	ctype := header.Get(hnContentType)
 	if ctype == "" && emptyContentTypeIsText {
 		return true
@@ -67,7 +67,7 @@ func detectTextHeader(header textproto.MIMEHeader, emptyContentTypeIsText bool) 
 
 // detectBinaryBody returns true if the mail header defines a binary body.
 func detectBinaryBody(root *Part) bool {
-	header := textproto.MIMEHeader(root.Header) // Use internal header methods.
+	header := inttp.MIMEHeader(root.Header) // Use internal header methods.
 	if detectTextHeader(header, true) {
 		// It is text/plain, but an attachment.
 		// Content-Type: text/plain; name="test.csv"

--- a/detect.go
+++ b/detect.go
@@ -67,23 +67,24 @@ func detectTextHeader(header textproto.MIMEHeader, emptyContentTypeIsText bool) 
 
 // detectBinaryBody returns true if the mail header defines a binary body.
 func detectBinaryBody(root *Part) bool {
-	if detectTextHeader(root.Header, true) {
+	header := textproto.MIMEHeader(root.Header) // Use internal header methods.
+	if detectTextHeader(header, true) {
 		// It is text/plain, but an attachment.
 		// Content-Type: text/plain; name="test.csv"
 		// Content-Disposition: attachment; filename="test.csv"
 		// Check for attachment only, or inline body is marked
 		// as attachment, too.
-		mtype, _, _, _ := mediatype.Parse(root.Header.Get(hnContentDisposition))
+		mtype, _, _, _ := mediatype.Parse(header.Get(hnContentDisposition))
 		return strings.ToLower(mtype) == cdAttachment
 	}
 
-	isBin := detectAttachmentHeader(root.Header)
+	isBin := detectAttachmentHeader(header)
 	if !isBin {
 		// This must be an attachment, if the Content-Type is not
 		// 'text/plain' or 'text/html'.
 		// Example:
 		// Content-Type: application/pdf; name="doc.pdf"
-		mtype, _, _, _ := mediatype.Parse(root.Header.Get(hnContentType))
+		mtype, _, _, _ := mediatype.Parse(header.Get(hnContentType))
 		mtype = strings.ToLower(mtype)
 		if mtype != ctTextPlain && mtype != ctTextHTML {
 			return true

--- a/encode.go
+++ b/encode.go
@@ -6,12 +6,12 @@ import (
 	"io"
 	"mime"
 	"mime/quotedprintable"
+	"net/textproto"
 	"sort"
 	"time"
 
 	"github.com/jhillyerd/enmime/internal/coding"
 	"github.com/jhillyerd/enmime/internal/stringutil"
-	"github.com/jhillyerd/enmime/internal/textproto"
 )
 
 // b64Percent determines the percent of non-ASCII characters enmime will tolerate before switching

--- a/envelope.go
+++ b/envelope.go
@@ -5,13 +5,13 @@ import (
 	"io"
 	"mime"
 	"net/mail"
-	nettp "net/textproto"
+	"net/textproto"
 	"strings"
 	"time"
 
 	"github.com/jaytaylor/html2text"
 	"github.com/jhillyerd/enmime/internal/coding"
-	"github.com/jhillyerd/enmime/internal/textproto"
+	inttp "github.com/jhillyerd/enmime/internal/textproto"
 	"github.com/jhillyerd/enmime/mediatype"
 
 	"github.com/pkg/errors"
@@ -27,8 +27,8 @@ type Envelope struct {
 	// All non-text parts that were not placed in Attachments or Inlines, such as multipart/related
 	// content.
 	OtherParts []*Part
-	Errors     []*Error          // Errors encountered while parsing
-	header     *nettp.MIMEHeader // Header from original message
+	Errors     []*Error              // Errors encountered while parsing
+	header     *textproto.MIMEHeader // Header from original message
 }
 
 // GetHeaderKeys returns a list of header keys seen in this message. Get
@@ -59,7 +59,7 @@ func (e *Envelope) GetHeaderValues(name string) []string {
 		return []string{}
 	}
 
-	rawValues := (*e.header)[textproto.CanonicalEmailMIMEHeaderKey(name)]
+	rawValues := (*e.header)[inttp.CanonicalEmailMIMEHeaderKey(name)]
 	values := make([]string, 0, len(rawValues))
 	for _, v := range rawValues {
 		values = append(values, coding.DecodeExtHeader(v))

--- a/envelope.go
+++ b/envelope.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"mime"
 	"net/mail"
+	nettp "net/textproto"
 	"strings"
 	"time"
 
@@ -26,8 +27,8 @@ type Envelope struct {
 	// All non-text parts that were not placed in Attachments or Inlines, such as multipart/related
 	// content.
 	OtherParts []*Part
-	Errors     []*Error              // Errors encountered while parsing
-	header     *textproto.MIMEHeader // Header from original message
+	Errors     []*Error          // Errors encountered while parsing
+	header     *nettp.MIMEHeader // Header from original message
 }
 
 // GetHeaderKeys returns a list of header keys seen in this message. Get

--- a/header.go
+++ b/header.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"mime"
 	"net/mail"
+	nettp "net/textproto"
 	"strings"
 
 	"github.com/jhillyerd/enmime/internal/coding"
@@ -120,7 +121,7 @@ func ParseMediaType(ctype string) (mtype string, params map[string]string, inval
 
 // readHeader reads a block of SMTP or MIME headers and returns a textproto.MIMEHeader.
 // Header parse warnings & errors will be added to p.Errors, io errors will be returned directly.
-func readHeader(r *bufio.Reader, p *Part) (textproto.MIMEHeader, error) {
+func readHeader(r *bufio.Reader, p *Part) (nettp.MIMEHeader, error) {
 	// buf holds the massaged output for textproto.Reader.ReadMIMEHeader()
 	buf := &bytes.Buffer{}
 	tp := textproto.NewReader(r)
@@ -194,7 +195,7 @@ line:
 	buf.Write([]byte{'\r', '\n'})
 	tr := textproto.NewReader(bufio.NewReader(buf))
 	header, err := tr.ReadEmailMIMEHeader()
-	return header, errors.WithStack(err)
+	return nettp.MIMEHeader(header), errors.WithStack(err)
 }
 
 // decodeToUTF8Base64Header decodes a MIME header per RFC 2047, reencoding to =?utf-8b?

--- a/part.go
+++ b/part.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/rand"
 	"mime/quotedprintable"
+	nettp "net/textproto"
 	"strconv"
 	"strings"
 	"time"
@@ -27,11 +28,11 @@ const (
 // Part represents a node in the MIME multipart tree.  The Content-Type, Disposition and File Name
 // are parsed out of the header for easier access.
 type Part struct {
-	PartID      string               // PartID labels this part's position within the tree.
-	Parent      *Part                // Parent of this part (can be nil.)
-	FirstChild  *Part                // FirstChild is the top most child of this part.
-	NextSibling *Part                // NextSibling of this part.
-	Header      textproto.MIMEHeader // Header for this part.
+	PartID      string           // PartID labels this part's position within the tree.
+	Parent      *Part            // Parent of this part (can be nil.)
+	FirstChild  *Part            // FirstChild is the top most child of this part.
+	NextSibling *Part            // NextSibling of this part.
+	Header      nettp.MIMEHeader // Header for this part.
 
 	Boundary          string            // Boundary marker used within this part.
 	ContentID         string            // ContentID header for cid URL scheme.
@@ -56,7 +57,7 @@ type Part struct {
 // NewPart creates a new Part object.
 func NewPart(contentType string) *Part {
 	return &Part{
-		Header:            make(textproto.MIMEHeader),
+		Header:            make(nettp.MIMEHeader),
 		ContentType:       contentType,
 		ContentTypeParams: make(map[string]string),
 		parser:            &defaultParser,
@@ -115,7 +116,7 @@ func (p *Part) setupHeaders(r *bufio.Reader, defaultContentType string) error {
 	if err != nil {
 		return err
 	}
-	p.Header = header
+	p.Header = nettp.MIMEHeader(header)
 	ctype := header.Get(hnContentType)
 	if ctype == "" {
 		if defaultContentType == "" {
@@ -146,8 +147,9 @@ func (p *Part) setupHeaders(r *bufio.Reader, defaultContentType string) error {
 // setupContentHeaders uses Content-Type media params and Content-Disposition headers to populate
 // the disposition, filename, and charset fields.
 func (p *Part) setupContentHeaders(mediaParams map[string]string) {
+	header := textproto.MIMEHeader(p.Header)
 	// Determine content disposition, filename, character set.
-	disposition, dparams, _, err := mediatype.Parse(p.Header.Get(hnContentDisposition))
+	disposition, dparams, _, err := mediatype.Parse(header.Get(hnContentDisposition))
 	if err == nil {
 		// Disposition is optional
 		p.Disposition = disposition
@@ -269,12 +271,13 @@ func (p *Part) convertFromStatedCharset(r io.Reader) io.Reader {
 // placing the result into Part.Content.  IO errors will be returned immediately; other errors
 // and warnings will be added to Part.Errors.
 func (p *Part) decodeContent(r io.Reader, readPartErrorPolicy ReadPartErrorPolicy) error {
+	header := textproto.MIMEHeader(p.Header)
 	// contentReader will point to the end of the content decoding pipeline.
 	contentReader := r
 	// b64cleaner aggregates errors, must maintain a reference to it to get them later.
 	var b64cleaner *coding.Base64Cleaner
 	// Build content decoding reader.
-	encoding := p.Header.Get(hnContentEncoding)
+	encoding := header.Get(hnContentEncoding)
 	validEncoding := true
 	switch strings.ToLower(encoding) {
 	case cteQuotedPrintable:


### PR DESCRIPTION
We did not intend for the external API to change when hosting our own version
of textproto.

Fixes #294
