### PR TITLE
Remove deprecated packages

### DIFF
--- a/boundary.go
+++ b/boundary.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"unicode"
 )
 
@@ -177,7 +176,7 @@ func (b *boundaryReader) Next() (bool, error) {
 	}
 	if b.partsRead > 0 {
 		// Exhaust the current part to prevent errors when moving to the next part.
-		_, _ = io.Copy(ioutil.Discard, b)
+		_, _ = io.Copy(io.Discard, b)
 	}
 	for {
 		var line []byte = nil

--- a/boundary_test.go
+++ b/boundary_test.go
@@ -3,12 +3,11 @@ package enmime
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"io/ioutil"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 func TestBoundaryReader(t *testing.T) {
@@ -464,7 +463,7 @@ func TestBoundaryReaderReadErrors(t *testing.T) {
 	if n != 0 {
 		t.Fatal("Read() should not have read any bytes, failed")
 	}
-	if errors.Cause(err) != bufio.ErrBufferFull {
+	if !errors.Is(err, bufio.ErrBufferFull) {
 		t.Fatal("Read() should have returned bufio.ErrBufferFull error, failed")
 	}
 	// Next method to return a non io.EOF error.
@@ -472,7 +471,7 @@ func TestBoundaryReaderReadErrors(t *testing.T) {
 	if next {
 		t.Fatal("Next() should have returned false, failed")
 	}
-	if errors.Cause(err) != bufio.ErrBufferFull {
+	if !errors.Is(err, bufio.ErrBufferFull) {
 		t.Fatal("Read() should have returned bufio.ErrBufferFull error, failed")
 	}
 }

--- a/boundary_test.go
+++ b/boundary_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 )
@@ -74,7 +73,7 @@ func TestBoundaryReader(t *testing.T) {
 	for _, tt := range ttable {
 		ir := bufio.NewReader(strings.NewReader(tt.input))
 		br := newBoundaryReader(ir, tt.boundary)
-		output, err := ioutil.ReadAll(br)
+		output, err := io.ReadAll(br)
 		if err != nil {
 			t.Fatalf("Got error: %v\ninput: %q", err, tt.input)
 		}
@@ -86,7 +85,7 @@ func TestBoundaryReader(t *testing.T) {
 		}
 
 		// Test the data remaining in reader is correct
-		rest, err := ioutil.ReadAll(ir)
+		rest, err := io.ReadAll(ir)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -134,7 +133,7 @@ func TestBoundaryReaderEOF(t *testing.T) {
 
 	ir := bufio.NewReader(strings.NewReader(input))
 	br := newBoundaryReader(ir, boundary)
-	output, err := ioutil.ReadAll(br)
+	output, err := io.ReadAll(br)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +213,7 @@ func TestBoundaryReaderParts(t *testing.T) {
 			if !next {
 				t.Fatal("Next() = false, want: true")
 			}
-			output, err := ioutil.ReadAll(br)
+			output, err := io.ReadAll(br)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -354,7 +353,7 @@ func TestBoundaryReaderBufferBoundaryAbut(t *testing.T) {
 	if !next {
 		t.Fatal("Next() = false, want: true")
 	}
-	output, err := ioutil.ReadAll(br)
+	output, err := io.ReadAll(br)
 	if err != nil {
 		t.Fatalf("Got error: %v", err)
 	}
@@ -370,7 +369,7 @@ func TestBoundaryReaderBufferBoundaryAbut(t *testing.T) {
 	if !next {
 		t.Fatal("Next() = false, want: true")
 	}
-	output, err = ioutil.ReadAll(br)
+	output, err = io.ReadAll(br)
 	if err != nil {
 		t.Fatalf("Got error: %v", err)
 	}
@@ -410,7 +409,7 @@ func TestBoundaryReaderBufferBoundaryCross(t *testing.T) {
 	if !next {
 		t.Fatal("Next() = false, want: true")
 	}
-	output, err := ioutil.ReadAll(br)
+	output, err := io.ReadAll(br)
 	if err != nil {
 		t.Fatalf("Got error: %v", err)
 	}
@@ -426,7 +425,7 @@ func TestBoundaryReaderBufferBoundaryCross(t *testing.T) {
 	if !next {
 		t.Fatal("Next() = false, want: true")
 	}
-	output, err = ioutil.ReadAll(br)
+	output, err = io.ReadAll(br)
 	if err != nil {
 		t.Fatalf("Got error: %v", err)
 	}
@@ -548,7 +547,7 @@ func BenchmarkBoundaryReader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ir := bufio.NewReader(strings.NewReader(input))
 		br := newBoundaryReader(ir, boundary)
-		_, err = io.Copy(ioutil.Discard, br)
+		_, err = io.Copy(io.Discard, br)
 		if err != nil {
 			b.Fatalf("Failed to read content: %+v", err)
 		}

--- a/builder.go
+++ b/builder.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"mime"
 	"net/mail"
+	"os"
 	"path/filepath"
 	"reflect"
 	"time"
@@ -247,7 +247,7 @@ func (p MailBuilder) AddFileAttachment(path string) MailBuilder {
 	if p.err != nil {
 		return p
 	}
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		p.err = err
 		return p
@@ -282,7 +282,7 @@ func (p MailBuilder) AddFileInline(path string) MailBuilder {
 	if p.err != nil {
 		return p
 	}
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		p.err = err
 		return p
@@ -317,7 +317,7 @@ func (p MailBuilder) AddFileOtherPart(path string) MailBuilder {
 	if p.err != nil {
 		return p
 	}
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		p.err = err
 		return p

--- a/cmd/mime-extractor/mime-extractor.go
+++ b/cmd/mime-extractor/mime-extractor.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -35,7 +34,7 @@ func newDefaultExtractor() *extractor {
 		stdOut:    os.Stdout,
 		exit:      os.Exit,
 		wd:        os.Getwd,
-		fileWrite: ioutil.WriteFile,
+		fileWrite: os.WriteFile,
 	}
 }
 

--- a/cmd/mime-extractor/mime-extractor_test.go
+++ b/cmd/mime-extractor/mime-extractor_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +20,7 @@ func TestExtractEmptyFilename(t *testing.T) {
 	b := &bytes.Buffer{}
 	testExtractor := &extractor{
 		errOut: b,
-		stdOut: ioutil.Discard,
+		stdOut: io.Discard,
 	}
 	exitCode := testExtractor.extract("", "")
 	if exitCode != 1 {
@@ -38,7 +38,7 @@ func TestExtractEmptyOutputDirectory(t *testing.T) {
 	}
 	testExtractor := &extractor{
 		errOut: b,
-		stdOut: ioutil.Discard,
+		stdOut: io.Discard,
 		wd:     workingDirectoryFn,
 	}
 	exitCode := testExtractor.extract("some.file", "")
@@ -54,7 +54,7 @@ func TestExtractFailedToOpenFile(t *testing.T) {
 	b := &bytes.Buffer{}
 	testExtractor := &extractor{
 		errOut: b,
-		stdOut: ioutil.Discard,
+		stdOut: io.Discard,
 		wd:     os.Getwd,
 	}
 	exitCode := testExtractor.extract("some.file", "")
@@ -70,7 +70,7 @@ func TestExtractFailedToParse(t *testing.T) {
 	s := &bytes.Buffer{}
 	testExtractor := &extractor{
 		errOut: s,
-		stdOut: ioutil.Discard,
+		stdOut: io.Discard,
 		wd:     os.Getwd,
 	}
 	exitCode := testExtractor.extract(filepath.Join("..", "..", "testdata", "mail", "erroneous.raw"), "")
@@ -88,7 +88,7 @@ func TestExtractAttachmentWriteFail(t *testing.T) {
 		return fmt.Errorf("AttachmentWriteFail")
 	}
 	testExtractor := &extractor{
-		errOut:    ioutil.Discard,
+		errOut:    io.Discard,
 		stdOut:    s,
 		wd:        os.Getwd,
 		fileWrite: fw,
@@ -111,7 +111,7 @@ func TestExtractSuccess(t *testing.T) {
 	}
 	testExtractor := &extractor{
 		errOut:    b,
-		stdOut:    ioutil.Discard,
+		stdOut:    io.Discard,
 		wd:        os.Getwd,
 		fileWrite: fw,
 	}

--- a/envelope.go
+++ b/envelope.go
@@ -12,8 +12,6 @@ import (
 	"github.com/jhillyerd/enmime/internal/coding"
 	"github.com/jhillyerd/enmime/internal/textproto"
 	"github.com/jhillyerd/enmime/mediatype"
-
-	"github.com/pkg/errors"
 )
 
 // Envelope is a simplified wrapper for MIME email messages.
@@ -158,7 +156,7 @@ func (p Parser) ReadEnvelope(r io.Reader) (*Envelope, error) {
 	// Read MIME parts from reader
 	root, err := p.ReadParts(r)
 	if err != nil {
-		return nil, errors.WithMessage(err, "Failed to ReadParts")
+		return nil, fmt.Errorf("failed to ReadParts: %w", err)
 	}
 	return p.EnvelopeFromPart(root)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/go-test/deep v1.0.7
 	github.com/gogs/chardet v0.0.0-20191104214054-4b6791f73a28
 	github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/text v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxm
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/header.go
+++ b/header.go
@@ -12,8 +12,6 @@ import (
 	"github.com/jhillyerd/enmime/internal/stringutil"
 	"github.com/jhillyerd/enmime/internal/textproto"
 	"github.com/jhillyerd/enmime/mediatype"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -194,7 +192,10 @@ line:
 	buf.Write([]byte{'\r', '\n'})
 	tr := textproto.NewReader(bufio.NewReader(buf))
 	header, err := tr.ReadEmailMIMEHeader()
-	return header, errors.WithStack(err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read header: %w", err)
+	}
+	return header, nil
 }
 
 // decodeToUTF8Base64Header decodes a MIME header per RFC 2047, reencoding to =?utf-8b?

--- a/inspect.go
+++ b/inspect.go
@@ -3,12 +3,11 @@ package enmime
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 
 	"github.com/jhillyerd/enmime/internal/coding"
 	"github.com/jhillyerd/enmime/internal/textproto"
-
-	"github.com/pkg/errors"
 )
 
 var defaultHeadersList = []string{
@@ -40,10 +39,9 @@ func DecodeHeaders(b []byte, addtlHeaders ...string) (textproto.MIMEHeader, erro
 	b = ensureHeaderBoundary(b)
 	tr := textproto.NewReader(bufio.NewReader(bytes.NewReader(b)))
 	headers, err := tr.ReadMIMEHeader()
-	switch errors.Cause(err) {
-	case nil, io.EOF:
-	// carry on, io.EOF is expected
-	default:
+
+	// io.EOF is expected
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 	headerList := defaultHeadersList

--- a/inspect_test.go
+++ b/inspect_test.go
@@ -3,7 +3,6 @@ package enmime_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/mail"
 	"strings"
 	"testing"
@@ -39,7 +38,7 @@ func TestDecodeRFC2047(t *testing.T) {
 func TestDecodeHeaders(t *testing.T) {
 	t.Run("rfc2047 sample", func(t *testing.T) {
 		r := test.OpenTestData("mail", "qp-utf8-header.raw")
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			t.Errorf("%+v", err)
 		}
@@ -54,7 +53,7 @@ func TestDecodeHeaders(t *testing.T) {
 
 	t.Run("no break between headers and content", func(t *testing.T) {
 		r := test.OpenTestData("mail", "qp-utf8-header-no-break.raw")
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			t.Errorf("%+v", err)
 		}
@@ -69,7 +68,7 @@ func TestDecodeHeaders(t *testing.T) {
 
 	t.Run("textproto header read error", func(t *testing.T) {
 		r := test.OpenTestData("low-quality", "bad-header-start.raw")
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			t.Errorf("%+v", err)
 		}
@@ -84,7 +83,7 @@ func TestDecodeHeaders(t *testing.T) {
 
 	t.Run("rfc2047 recursive sample", func(t *testing.T) {
 		r := test.OpenTestData("mail", "qp-utf8-header-recursed.raw")
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			t.Errorf("%+v", err)
 		}
@@ -100,7 +99,7 @@ func TestDecodeHeaders(t *testing.T) {
 
 func BenchmarkHumanHeadersOnly(b *testing.B) {
 	r := test.OpenTestData("mail", "qp-utf8-header.raw")
-	eml, err := ioutil.ReadAll(r)
+	eml, err := io.ReadAll(r)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -123,7 +122,7 @@ func BenchmarkHumanHeadersOnly(b *testing.B) {
 
 func BenchmarkReadEnvelope(b *testing.B) {
 	r := test.OpenTestData("mail", "qp-utf8-header.raw")
-	eml, err := ioutil.ReadAll(r)
+	eml, err := io.ReadAll(r)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/coding/charsets.go
+++ b/internal/coding/charsets.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strings"
 
@@ -307,7 +306,7 @@ func ConvertToUTF8String(charset string, textBytes []byte) (string, error) {
 	}
 	input := bytes.NewReader(textBytes)
 	reader := transform.NewReader(input, csentry.e.NewDecoder())
-	output, err := ioutil.ReadAll(reader)
+	output, err := io.ReadAll(reader)
 	if err != nil {
 		return "", err
 	}

--- a/internal/coding/charsets_test.go
+++ b/internal/coding/charsets_test.go
@@ -2,7 +2,7 @@ package coding_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -40,7 +40,7 @@ func TestCharsetReader(t *testing.T) {
 		if err != nil {
 			t.Error("err should be nil, got:", err)
 		}
-		result, err := ioutil.ReadAll(outputReader)
+		result, err := io.ReadAll(outputReader)
 		if err != nil {
 			t.Error("err should be nil, got:", err)
 		}

--- a/internal/coding/quotedprint_test.go
+++ b/internal/coding/quotedprint_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -110,7 +109,7 @@ func TestQPCleanerLineBreak(t *testing.T) {
 	inbuf := bytes.NewBuffer(input)
 	qp := coding.NewQPCleaner(inbuf)
 
-	output, err := ioutil.ReadAll(qp)
+	output, err := io.ReadAll(qp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/test/golden.go
+++ b/internal/test/golden.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -129,14 +129,14 @@ func DiffGolden(t *testing.T, got []byte, path ...string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	golden, err := ioutil.ReadAll(f)
+	golden, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(got, golden) {
 		if *update {
 			// Update golden file
-			if err := ioutil.WriteFile(pathstr, got, 0666); err != nil {
+			if err := os.WriteFile(pathstr, got, 0666); err != nil {
 				t.Fatal(err)
 			}
 		} else {

--- a/mediatype/mediatype.go
+++ b/mediatype/mediatype.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/jhillyerd/enmime/internal/coding"
 	"github.com/jhillyerd/enmime/internal/stringutil"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -44,7 +43,7 @@ func Parse(ctype string) (mtype string, params map[string]string, invalidParams 
 		if err.Error() == "mime: no media type" {
 			return "", nil, nil, nil
 		}
-		return "", nil, nil, errors.WithStack(err)
+		return "", nil, nil, fmt.Errorf("parsing failed: %w", err)
 	}
 
 	if mtype == ctPlaceholder {

--- a/part.go
+++ b/part.go
@@ -329,10 +329,6 @@ func IsBase64CorruptInputError(err error) bool {
 		return false
 	}
 	_, ok := err.(base64.CorruptInputError)
-	for !ok && err != nil {
-		err = errors.Unwrap(err)
-		_, ok = err.(base64.CorruptInputError)
-	}
 	return ok
 }
 

--- a/part.go
+++ b/part.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"mime/quotedprintable"
 	"strconv"
@@ -169,7 +168,7 @@ func (p *Part) setupContentHeaders(mediaParams map[string]string) {
 }
 
 func (p *Part) readPartContent(r io.Reader, readPartErrorPolicy ReadPartErrorPolicy) ([]byte, error) {
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		if readPartErrorPolicy != nil && readPartErrorPolicy(p, err) {
 			p.addWarning(ErrorMalformedChildPart, "partial content: %s", err.Error())
@@ -467,7 +466,7 @@ func parseParts(parent *Part, reader *bufio.Reader) error {
 	}
 
 	// Store any content following the closing boundary marker into the epilogue.
-	epilogue, err := ioutil.ReadAll(reader)
+	epilogue, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("failed to parse parts: %w", err)
 	}


### PR DESCRIPTION
- Remove `github.com/pkg/errors`, which is archived since 2021.
- Remove `ioutil`, which is deprecated since Go 1.16