### PR TITLE
fix: don't remove CTE header when using the RawContent parser option

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -99,7 +99,9 @@ func (p *Part) setupMIMEHeaders() transferEncoding {
 
 	// If we are encoding a part that previously had content-transfer-encoding set, unset it so
 	// the correct encoding detection can be done below.
-	p.Header.Del(hnContentEncoding)
+	if p.parser != nil && !p.parser.rawContent {
+		p.Header.Del(hnContentEncoding)
+	}
 
 	cte := te7Bit
 	if len(p.Content) > 0 {

--- a/testdata/encode/parser-raw-content-option-true.raw.golden
+++ b/testdata/encode/parser-raw-content-option-true.raw.golden
@@ -1,3 +1,4 @@
+Content-Transfer-Encoding: quoted-printable
 Content-Type: text/html; charset=utf-8
 From: me@me.com
 Mime-Version: 1.0


### PR DESCRIPTION
Hi again, I missed this condition in my [last PR](https://github.com/jhillyerd/enmime/pull/304) sorry about that.
If we remove the "Content-Transfer-Encoding" header, the content may break. 