### PR TITLE
feat: skip empty parameters

### DIFF
--- a/mediatype/mediatype.go
+++ b/mediatype/mediatype.go
@@ -122,6 +122,12 @@ func fixMangledMediaType(mtype string, sep rune) string {
 			p = coding.RFC2047Decode(p)
 
 			pair := strings.SplitAfter(p, "=")
+
+			if strings.TrimSpace(pair[0]) == "=" {
+				// Ignore unnamed parameters.
+				continue
+			}
+
 			if strings.Contains(mtype, strings.TrimSpace(pair[0])) {
 				// Ignore repeated parameters.
 				continue

--- a/mediatype/mediatype_test.go
+++ b/mediatype/mediatype_test.go
@@ -47,6 +47,12 @@ func TestFixMangledMediaType(t *testing.T) {
 			want:  `image/png; name="abc.png"`,
 		},
 		{
+			// Removes empty parameters in the middle
+			input: `Content-Type: text/html; =""; charset=""`,
+			sep: ';',
+			want: `Content-Type: text/html; charset=""`,
+		},
+		{
 			input: "application/octet-stream;=?UTF-8?B?bmFtZT0iw7DCn8KUwoo=?=You've got a new voice miss call.msg",
 			sep:   ';',
 			want:  "application/octet-stream;name=\"ð\u009f\u0094\u008aYou've got a new voice miss call.msg\"",

--- a/mediatype/mediatype_test.go
+++ b/mediatype/mediatype_test.go
@@ -49,8 +49,8 @@ func TestFixMangledMediaType(t *testing.T) {
 		{
 			// Removes empty parameters in the middle
 			input: `Content-Type: text/html; =""; charset=""`,
-			sep: ';',
-			want: `Content-Type: text/html; charset=""`,
+			sep:   ';',
+			want:  `Content-Type: text/html; charset=""`,
 		},
 		{
 			input: "application/octet-stream;=?UTF-8?B?bmFtZT0iw7DCn8KUwoo=?=You've got a new voice miss call.msg",


### PR DESCRIPTION
Looks like there was never a proper condition for filtering out empty parameters. It kinda worked thanks to this https://github.com/jhillyerd/enmime/blob/main/mediatype/mediatype.go#L125-L128 (`=` substring would always match if there was at least one parameter already added to `mtype`). It did not work if the empty parameter was the first parameter.