### PR TITLE
Return public `net/textproto` error types

### DIFF
--- a/inspect_test.go
+++ b/inspect_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"io"
 	"net/mail"
+	"net/textproto"
 	"strings"
 	"testing"
 
 	"github.com/jhillyerd/enmime"
 	"github.com/jhillyerd/enmime/internal/test"
-	"github.com/jhillyerd/enmime/internal/textproto"
 )
 
 func TestDecodeRFC2047(t *testing.T) {

--- a/internal/textproto/reader_email.go
+++ b/internal/textproto/reader_email.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"math"
+	"net/textproto"
 )
 
 // ReadEmailMIMEHeader reads a MIME-style header from r.
@@ -32,7 +33,7 @@ func readEmailMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		if err != nil {
 			return m, err
 		}
-		return m, ProtocolError("malformed MIME header initial line: " + string(line))
+		return m, textproto.ProtocolError("malformed MIME header initial line: " + string(line))
 	}
 
 	for {
@@ -44,11 +45,11 @@ func readEmailMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		// Key ends at first colon.
 		k, v, ok := bytes.Cut(kv, colon)
 		if !ok {
-			return m, ProtocolError("malformed MIME header line: " + string(kv))
+			return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
 		}
 		key, ok := canonicalEmailMIMEHeaderKey(k)
 		if !ok {
-			return m, ProtocolError("malformed MIME header line: " + string(kv))
+			return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
 		}
 		// for _, c := range v {
 		// 	if !validHeaderValueByte(c) {

--- a/internal/textproto/reader_test.go
+++ b/internal/textproto/reader_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"io"
 	"net"
+	"net/textproto"
 	"reflect"
 	"strings"
 	"sync"
@@ -69,7 +70,7 @@ func TestReadCodeLine(t *testing.T) {
 	if code != 345 || msg != "no way" || err == nil {
 		t.Fatalf("Line 3: %d, %s, %v", code, msg, err)
 	}
-	if e, ok := err.(*Error); !ok || e.Code != code || e.Msg != msg {
+	if e, ok := err.(*textproto.Error); !ok || e.Code != code || e.Msg != msg {
 		t.Fatalf("Line 3: wrong error %v\n", err)
 	}
 	code, msg, err = r.ReadCodeLine(1)

--- a/internal/textproto/textproto.go
+++ b/internal/textproto/textproto.go
@@ -26,28 +26,9 @@ package textproto
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"net"
 )
-
-// An Error represents a numeric error response from a server.
-type Error struct {
-	Code int
-	Msg  string
-}
-
-func (e *Error) Error() string {
-	return fmt.Sprintf("%03d %s", e.Code, e.Msg)
-}
-
-// A ProtocolError describes a protocol violation such
-// as an invalid response or a hung-up connection.
-type ProtocolError string
-
-func (p ProtocolError) Error() string {
-	return string(p)
-}
 
 // A Conn represents a textual network protocol connection.
 // It consists of a Reader and Writer to manage I/O


### PR DESCRIPTION
To allow for checking returned error types, types from the standard library's `net/textproto` must be used instead of types from the private `textproto` fork.

Kind of related to #294.