### PR TITLE
fix: don't encode header value with the RawContent parser option

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -170,15 +170,19 @@ func (p *Part) encodeHeader(b *bufio.Writer) error {
 	for k := range p.Header {
 		keys = append(keys, k)
 	}
+	rawContent := p.parser != nil && p.parser.rawContent
+
 	sort.Strings(keys)
 	for _, k := range keys {
 		for _, v := range p.Header[k] {
 			encv := v
-			switch selectTransferEncoding([]byte(v), true) {
-			case teBase64:
-				encv = mime.BEncoding.Encode(utf8, v)
-			case teQuoted:
-				encv = mime.QEncoding.Encode(utf8, v)
+			if !rawContent {
+				switch selectTransferEncoding([]byte(v), true) {
+				case teBase64:
+					encv = mime.BEncoding.Encode(utf8, v)
+				case teQuoted:
+					encv = mime.QEncoding.Encode(utf8, v)
+				}
 			}
 			// _ used to prevent early wrapping
 			wb := stringutil.Wrap(76, k, ":_", encv, "\r\n")

--- a/encode_test.go
+++ b/encode_test.go
@@ -426,7 +426,7 @@ func TestParseRawContentTextOptionFalse(t *testing.T) {
 	test.DiffGolden(t, b.Bytes(), "testdata", "encode", "parser-raw-content-text-option-false.raw.golden")
 }
 
-// TestRawContentUTF8Headers test if not encoded UTF8 headers are not edited with the rawContent parser option.
+// TestRawContentUTF8Headers verifies plain-text headers are unmodified with the rawContent parser option.
 func TestRawContentUTF8Headers(t *testing.T) {
 	r := test.OpenTestData("encode", "utf8-to.raw.golden")
 	p := enmime.NewParser(enmime.RawContent(true))

--- a/encode_test.go
+++ b/encode_test.go
@@ -425,3 +425,19 @@ func TestParseRawContentTextOptionFalse(t *testing.T) {
 	}
 	test.DiffGolden(t, b.Bytes(), "testdata", "encode", "parser-raw-content-text-option-false.raw.golden")
 }
+
+// TestRawContentUTF8Headers test if not encoded UTF8 headers are not edited with the rawContent parser option.
+func TestRawContentUTF8Headers(t *testing.T) {
+	r := test.OpenTestData("encode", "utf8-to.raw.golden")
+	p := enmime.NewParser(enmime.RawContent(true))
+	e, err := p.ReadEnvelope(r)
+	if err != nil {
+		t.Fatal("Failed to parse MIME:", err)
+	}
+	b := &bytes.Buffer{}
+	if err := e.Root.Encode(b); err != nil {
+		t.Fatal(err)
+	}
+
+	test.DiffGolden(t, b.Bytes(), "testdata", "encode", "utf8-to.raw.golden")
+}

--- a/testdata/encode/utf8-to.raw.golden
+++ b/testdata/encode/utf8-to.raw.golden
@@ -1,0 +1,7 @@
+Content-Type: text/plain; charset=utf-8
+From: Weiß foo@bar.com
+Mime-Version: 1.0
+Subject: test utf8 to
+To: Jøhn Døe <bar@baz.com>
+
+This is a test mailing


### PR DESCRIPTION
Hi, with this PR, I want to keep my header values like the original with the raw content parser option set to true.