### PR TITLE
chore: fixed timezone for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 	go build
 
 test:
-	TZ=Europe/London go test -race ./...
+	go test -race ./...
 
 fmt:
 	@gofmt -l -w $(SRC)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 	go build
 
 test:
-	go test -race ./...
+	TZ=Europe/London go test -race ./...
 
 fmt:
 	@gofmt -l -w $(SRC)

--- a/encode.go
+++ b/encode.go
@@ -154,7 +154,7 @@ func (p *Part) setupMIMEHeaders() transferEncoding {
 		param := make(map[string]string)
 		setParamValue(param, hpFilename, fileName)
 		if !p.FileModDate.IsZero() {
-			setParamValue(param, hpModDate, p.FileModDate.Format(time.RFC822))
+			setParamValue(param, hpModDate, p.FileModDate.UTC().Format(time.RFC822))
 		}
 		if mt := mime.FormatMediaType(p.Disposition, param); mt != "" {
 			p.Disposition = mt

--- a/testdata/encode/part-default-headers.golden
+++ b/testdata/encode/part-default-headers.golden
@@ -1,5 +1,5 @@
 Content-Disposition: attachment; filename=stuff.zip; modification-date="01
- Feb 03 04:05 GMT"
+ Feb 03 04:05 UTC"
 Content-Id: <mycontentid>
 Content-Transfer-Encoding: base64
 Content-Type: application/zip; boundary=enmime-abcdefg0123456789;

--- a/testdata/encode/part-file-mod-date.golden
+++ b/testdata/encode/part-file-mod-date.golden
@@ -1,4 +1,4 @@
-Content-Disposition: inline; modification-date="01 Feb 03 04:05 GMT"
+Content-Disposition: inline; modification-date="01 Feb 03 04:05 UTC"
 Content-Transfer-Encoding: quoted-printable
 Content-Type: text/plain; charset=utf-8
 

--- a/testdata/encode/part-quoted-headers.golden
+++ b/testdata/encode/part-quoted-headers.golden
@@ -1,6 +1,6 @@
 Content-Disposition: attachment;
  filename="=?utf-8?b?w6FydsOtenTFsXLFkSAieCIgdMO8a8O2cmbDunLDs2fDqXAuemlw?=";
- modification-date="01 Feb 03 04:05 GMT"
+ modification-date="01 Feb 03 04:05 UTC"
 Content-Id: <mycontentid>
 Content-Transfer-Encoding: base64
 Content-Type: application/zip; boundary=enmime-abcdefg0123456789;

--- a/testdata/encode/part-quoted-printable-headers.golden
+++ b/testdata/encode/part-quoted-printable-headers.golden
@@ -1,6 +1,6 @@
 Content-Disposition: attachment;
  filename="=?utf-8?b?w6FydsOtenTFsXLFkSAieCIgdMO8a8O2cmbDunLDs2fDqXAuemlw?=";
- modification-date="01 Feb 03 04:05 GMT"
+ modification-date="01 Feb 03 04:05 UTC"
 Content-Id: <mycontentid>
 Content-Transfer-Encoding: base64
 Content-Type: application/zip; boundary=enmime-abcdefg0123456789;


### PR DESCRIPTION
The tests are failing when ran in a TZ different from GMT.

```
--- FAIL: TestEncodePartDefaultHeaders (0.00s)
    encode_test.go:71: Test output did not match testdata/encode/part-default-headers.golden
        To update golden file, run: go test -update
    encode_test.go:71: diff -want +got:
        | Content-Disposition: attachment; filename=stuff.zip; modification-date="01
        |- Feb 03 04:05 GMT"
        |+ Feb 03 05:05 CET"
        | Content-Id: <mycontentid>
        | Content-Transfer-Encoding: base64
        ...
        | WklQWklQWklQ
        | 
```

This PR fixates test run to TZ=Europe/London