### PR TITLE
fix: do not setup MIME headers with the rawContent option set to true

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -50,7 +50,10 @@ func (p *Part) Encode(writer io.Writer) error {
 		}
 		p.Content = p.Content[:n]
 	}
-	cte := p.setupMIMEHeaders()
+	cte := teRaw
+	if p.parser == nil || !p.parser.rawContent {
+		cte = p.setupMIMEHeaders()
+	}
 	// Encode this part.
 	b := bufio.NewWriter(writer)
 	if err := p.encodeHeader(b); err != nil {
@@ -99,9 +102,7 @@ func (p *Part) setupMIMEHeaders() transferEncoding {
 
 	// If we are encoding a part that previously had content-transfer-encoding set, unset it so
 	// the correct encoding detection can be done below.
-	if p.parser != nil && !p.parser.rawContent {
-		p.Header.Del(hnContentEncoding)
-	}
+	p.Header.Del(hnContentEncoding)
 
 	cte := te7Bit
 	if len(p.Content) > 0 {

--- a/testdata/encode/parser-raw-content-html-option-false.raw.golden
+++ b/testdata/encode/parser-raw-content-html-option-false.raw.golden
@@ -1,7 +1,9 @@
+Content-Transfer-Encoding: quoted-printable
 Content-Type: text/html; charset=utf-8
 From: me@me.com
 Mime-Version: 1.0
 Subject: Test subject
 To: you@you.com
 
-<!DOCTYPE html><html><body><h1>My First Heading</h1><p>My first paragraph.</p></body></html>
+<!DOCTYPE html><html><body><h1>My First Heading</h1><p>My first paragraph =
+=C3=A9=C3=A0.</p></body></html>

--- a/testdata/encode/parser-raw-content-html-option-true.raw.golden
+++ b/testdata/encode/parser-raw-content-html-option-true.raw.golden
@@ -1,9 +1,7 @@
-Content-Transfer-Encoding: quoted-printable
 Content-Type: text/html; charset=utf-8
 From: me@me.com
 Mime-Version: 1.0
 Subject: Test subject
 To: you@you.com
 
-<!DOCTYPE html><html><body><h1>My First Heading</h1><p>My first paragraph.<=
-/p></body></html>
+<!DOCTYPE html><html><body><h1>My First Heading</h1><p>My first paragraph éà.</p></body></html>

--- a/testdata/encode/parser-raw-content-html-option.raw
+++ b/testdata/encode/parser-raw-content-html-option.raw
@@ -2,8 +2,6 @@ Subject: Test subject
 From: me@me.com
 To: you@you.com
 MIME-Version: 1.0
-Content-Transfer-Encoding: quoted-printable
 Content-Type: text/html; charset=utf-8
 
-<!DOCTYPE html><html><body><h1>My First Heading</h1><p>My first paragraph.<=
-/p></body></html>
+<!DOCTYPE html><html><body><h1>My First Heading</h1><p>My first paragraph éà.</p></body></html>


### PR DESCRIPTION
Hi,

It's an improvement of the RawContent option to skip the function "setupMIMEHeaders" entirely. To avoid adding missing CTE header or try to correct them from the content.