### PR TITLE
chore: Resolve many linter warnings

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -902,7 +902,7 @@ func TestBuilderAddFileOtherPart(t *testing.T) {
 
 	a = enmime.Builder().From("name", "from")
 	_ = a.AddFileOtherPart("zzzDOESNOTEXIST")
-	assert.NoError(t, a.Error(), "AddFileOtherPart error mutated receiver")
+	require.NoError(t, a.Error(), "AddFileOtherPart error mutated receiver")
 
 	a = enmime.Builder().AddFileOtherPart(filepath.Join("testdata", "attach", "fake.png"))
 	require.NoError(t, a.Error())

--- a/cmd/mime-extractor/mime-extractor_test.go
+++ b/cmd/mime-extractor/mime-extractor_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -85,7 +85,7 @@ func TestExtractFailedToParse(t *testing.T) {
 func TestExtractAttachmentWriteFail(t *testing.T) {
 	s := &bytes.Buffer{}
 	fw := func(filename string, data []byte, perm os.FileMode) error {
-		return fmt.Errorf("AttachmentWriteFail")
+		return errors.New("AttachmentWriteFail")
 	}
 	testExtractor := &extractor{
 		errOut:    io.Discard,

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -168,7 +168,7 @@ func FormatPart(w io.Writer, p *enmime.Part, indent string) {
 	}
 	disposition := ""
 	if p.Disposition != "" {
-		disposition = fmt.Sprintf(", disposition: %s", p.Disposition)
+		disposition = ", disposition: " + p.Disposition
 	}
 	filename := ""
 	if p.FileName != "" {

--- a/encode_test.go
+++ b/encode_test.go
@@ -345,19 +345,19 @@ func TestEncodePartContentNonAsciiText(t *testing.T) {
 		threshold + 1,
 	}
 
-	for _, numNonAscii := range cases {
-		nonAscii := bytes.Repeat([]byte{byte(0x10)}, numNonAscii)
-		ascii := bytes.Repeat([]byte{0x41}, 100-numNonAscii)
+	for _, numNonASCII := range cases {
+		nonASCII := bytes.Repeat([]byte{byte(0x10)}, numNonASCII)
+		ascii := bytes.Repeat([]byte{0x41}, 100-numNonASCII)
+		nonASCII = append(nonASCII, ascii...)
 
-		p.Content = append(nonAscii, ascii[:]...)
-
+		p.Content = nonASCII
 		b := &bytes.Buffer{}
 		err := p.Encode(b)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if numNonAscii < threshold {
+		if numNonASCII < threshold {
 			test.DiffStrings(t, []string{p.Header.Get("Content-Transfer-Encoding")}, []string{"quoted-printable"})
 		} else {
 			test.DiffStrings(t, []string{p.Header.Get("Content-Transfer-Encoding")}, []string{"base64"})

--- a/envelope.go
+++ b/envelope.go
@@ -69,7 +69,7 @@ func (e *Envelope) GetHeaderValues(name string) []string {
 // If the header exists already, all existing values are replaced.
 func (e *Envelope) SetHeader(name string, value []string) error {
 	if name == "" {
-		return fmt.Errorf("provide non-empty header name")
+		return errors.New("provide non-empty header name")
 	}
 
 	for i, v := range value {
@@ -86,7 +86,7 @@ func (e *Envelope) SetHeader(name string, value []string) error {
 // If the header does not exist already, it will be created.
 func (e *Envelope) AddHeader(name string, value string) error {
 	if name == "" {
-		return fmt.Errorf("provide non-empty header name")
+		return errors.New("provide non-empty header name")
 	}
 
 	e.header.Add(name, mime.BEncoding.Encode("utf-8", value))
@@ -96,7 +96,7 @@ func (e *Envelope) AddHeader(name string, value string) error {
 // DeleteHeader deletes given header.
 func (e *Envelope) DeleteHeader(name string) error {
 	if name == "" {
-		return fmt.Errorf("provide non-empty header name")
+		return errors.New("provide non-empty header name")
 	}
 
 	e.header.Del(name)
@@ -106,7 +106,7 @@ func (e *Envelope) DeleteHeader(name string) error {
 // AddressList returns a mail.Address slice with RFC 2047 encoded names converted to UTF-8
 func (e *Envelope) AddressList(key string) ([]*mail.Address, error) {
 	if e.header == nil {
-		return nil, fmt.Errorf("no headers available")
+		return nil, errors.New("no headers available")
 	}
 	if !AddressHeaders[strings.ToLower(key)] {
 		return nil, fmt.Errorf("%s is not an address header", key)
@@ -272,7 +272,7 @@ func parseMultiPartBody(root *Part, e *Envelope) error {
 	}
 	boundary := params[hpBoundary]
 	if boundary == "" {
-		return fmt.Errorf("unable to locate boundary param in Content-Type header")
+		return errors.New("unable to locate boundary param in Content-Type header")
 	}
 
 	// Locate text body

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -30,7 +30,7 @@ func TestParseHeaderOnly(t *testing.T) {
 		t.Errorf("Expected no HTML body, got %q", e.HTML)
 	}
 	if e.Root == nil {
-		t.Errorf("Expected a root part")
+		t.Error("Expected a root part")
 	}
 	if len(e.Root.Header) != 7 {
 		t.Errorf("Expected 7 headers, got %d", len(e.Root.Header))
@@ -998,11 +998,11 @@ func TestAttachmentOnly(t *testing.T) {
 		}
 		// Check, if root header is set
 		if len(e.Root.Header) < 1 {
-			t.Errorf("No root header defined, but must be set from binary only part.")
+			t.Error("No root header defined, but must be set from binary only part.")
 		}
 		// Check, that the root part has content
 		if len(e.Root.Content) == 0 {
-			t.Errorf("Root part of envelope has no content.")
+			t.Error("Root part of envelope has no content.")
 		}
 	}
 }

--- a/inspect_test.go
+++ b/inspect_test.go
@@ -16,21 +16,21 @@ func TestDecodeRFC2047(t *testing.T) {
 	t.Run("rfc2047 basic", func(t *testing.T) {
 		s := enmime.DecodeRFC2047("=?UTF-8?Q?Miros=C5=82aw_Marczak?=")
 		if s != "Mirosław Marczak" {
-			t.Errorf("Wrong decoded result")
+			t.Error("Wrong decoded result")
 		}
 	})
 
 	t.Run("rfc2047 unknown", func(t *testing.T) {
 		s := enmime.DecodeRFC2047("=?ABC-1?Q?FooBar?=")
 		if s != "=?ABC-1?Q?FooBar?=" {
-			t.Errorf("Expected unmodified result for unknown charset")
+			t.Error("Expected unmodified result for unknown charset")
 		}
 	})
 
 	t.Run("rfc2047 pass-through", func(t *testing.T) {
 		s := enmime.DecodeRFC2047("Hello World")
 		if s != "Hello World" {
-			t.Errorf("Expected unmodified result")
+			t.Error("Expected unmodified result")
 		}
 	})
 }
@@ -47,7 +47,7 @@ func TestDecodeHeaders(t *testing.T) {
 			t.Errorf("%+v", err)
 		}
 		if !strings.Contains(h.Get("To"), "Mirosław Marczak") {
-			t.Errorf("Error decoding RFC2047 header value")
+			t.Error("Error decoding RFC2047 header value")
 		}
 	})
 
@@ -62,7 +62,7 @@ func TestDecodeHeaders(t *testing.T) {
 			t.Errorf("%+v", err)
 		}
 		if !strings.Contains(h.Get("To"), "Mirosław Marczak") {
-			t.Errorf("Error decoding RFC2047 header value")
+			t.Error("Error decoding RFC2047 header value")
 		}
 	})
 
@@ -92,7 +92,7 @@ func TestDecodeHeaders(t *testing.T) {
 			t.Errorf("%+v", err)
 		}
 		if !strings.Contains(h.Get("From"), "WirelessCaller (203) 402-5984 WirelessCaller (203) 402-5984 WirelessCaller (203) 402-5984") {
-			t.Errorf("Error decoding recursive RFC2047 header value")
+			t.Error("Error decoding recursive RFC2047 header value")
 		}
 	})
 }

--- a/internal/coding/headerext.go
+++ b/internal/coding/headerext.go
@@ -61,10 +61,10 @@ func RFC2047Decode(s string) string {
 
 				// Add quotes as needed.
 				if !strings.HasPrefix(value, "\"") {
-					value = fmt.Sprintf("\"%s", value)
+					value = `"` + value
 				}
 				if !strings.HasSuffix(value, "\"") {
-					value = fmt.Sprintf("%s\"", value)
+					value += `"`
 				}
 
 				return fmt.Sprintf("%s=%s", key, value)

--- a/internal/coding/idheader.go
+++ b/internal/coding/idheader.go
@@ -22,5 +22,5 @@ func FromIDHeader(v string) string {
 // ToIDHeader encodes a Content-ID or Message-ID header value (RFC 2392) from a utf-8 string.
 func ToIDHeader(v string) string {
 	v = url.QueryEscape(v)
-	return "<" + strings.Replace(v, "%40", "@", -1) + ">"
+	return "<" + strings.ReplaceAll(v, "%40", "@") + ">"
 }

--- a/internal/stringutil/uuid_test.go
+++ b/internal/stringutil/uuid_test.go
@@ -4,15 +4,12 @@ import (
 	"testing"
 
 	"github.com/jhillyerd/enmime/internal/stringutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUUID(t *testing.T) {
 	id1 := stringutil.UUID(nil)
 	id2 := stringutil.UUID(nil)
 
-	if id1 == id2 {
-		t.Errorf("Random UUID should not equal another random UUID")
-		t.Logf("id1: %q", id1)
-		t.Logf("id2: %q", id2)
-	}
+	assert.NotEqual(t, id1, id2, "Random UUID should not equal another random UUID")
 }

--- a/internal/textproto/reader.go
+++ b/internal/textproto/reader.go
@@ -127,7 +127,7 @@ func (r *Reader) ReadContinuedLineBytes() ([]byte, error) {
 // error is returned from readContinuedLineSlice.
 func (r *Reader) readContinuedLineSlice(validateFirstLine func([]byte) error) ([]byte, error) {
 	if validateFirstLine == nil {
-		return nil, fmt.Errorf("missing validateFirstLine func")
+		return nil, errors.New("missing validateFirstLine func")
 	}
 
 	// Read the first line.

--- a/internal/textproto/reader.go
+++ b/internal/textproto/reader.go
@@ -168,6 +168,8 @@ func (r *Reader) readContinuedLineSlice(validateFirstLine func([]byte) error) ([
 		r.buf = append(r.buf, ' ')
 		r.buf = append(r.buf, trim(line)...)
 	}
+
+	//lint:ignore nilerr to maintain go stdlib compatibility.
 	return r.buf, nil
 }
 

--- a/internal/textproto/reader_test.go
+++ b/internal/textproto/reader_test.go
@@ -400,7 +400,7 @@ func TestIssue46363(t *testing.T) {
 	}
 }
 
-var clientHeaders = strings.Replace(`Host: golang.org
+var clientHeaders = strings.ReplaceAll(`Host: golang.org
 Connection: keep-alive
 Cache-Control: max-age=0
 Accept: application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -411,9 +411,9 @@ Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.3
 COOKIE: __utma=000000000.0000000000.0000000000.0000000000.0000000000.00; __utmb=000000000.0.00.0000000000; __utmc=000000000; __utmz=000000000.0000000000.00.0.utmcsr=code.google.com|utmccn=(referral)|utmcmd=referral|utmcct=/p/go/issues/detail
 Non-Interned: test
 
-`, "\n", "\r\n", -1)
+`, "\n", "\r\n")
 
-var serverHeaders = strings.Replace(`Content-Type: text/html; charset=utf-8
+var serverHeaders = strings.ReplaceAll(`Content-Type: text/html; charset=utf-8
 Content-Encoding: gzip
 Date: Thu, 27 Sep 2012 09:03:33 GMT
 Server: Google Frontend
@@ -423,7 +423,7 @@ VIA: 1.1 proxy.example.com:80 (XXX/n.n.n-nnn)
 Connection: Close
 Non-Interned: test
 
-`, "\n", "\r\n", -1)
+`, "\n", "\r\n")
 
 func BenchmarkReadMIMEHeader(b *testing.B) {
 	b.ReportAllocs()


### PR DESCRIPTION
- style: use ReplaceAll instead of Replace
- encode_test: resolve several style warnings
- style: use require to appease testify linter
- textproto: ignore lint for stdlib api
- chore: remove unneeded sprintf calls

For #320 
