### PR TITLE
actions: update linter config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.0
+          version: v1.56.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,22 +2,74 @@ run:
   timeout: 5m
 linters:
   enable:
+    - asasalint
     - asciicheck
+    - bidichk
     - bodyclose
-    - deadcode
+    - containedctx
+    - contextcheck
+    - decorder
+    # - dupl
+    # - dupword
+    - durationcheck
+    - errchkjson
+    - errname
+    # - errorlint
+    - execinquery
+    # - exhaustive
     - exportloopref
-    - errcheck
+    # - forcetypeassert
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    # - gochecknoinits
+    - gochecksumtype
+    - gocritic
+    # - godot
+    # - goerr113
     - gofmt
+    # - gofumpt
+    - goheader
     - goimports
-    - gosimple
-    - govet
-    - ineffassign
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    # - gosec
+    - gosmopolitan
+    - grouper
+    - importas
+    - inamedparam
+    - interfacebloat
+    - loggercheck
+    - makezero
+    - mirror
     - misspell
-    - megacheck
+    - musttag
+    - nilerr
+    # - nilnil
+    # - nlreturn
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - perfsprint
     - prealloc
+    - predeclared
+    - promlinter
+    - protogetter
+    - reassign
+    # - revive
     - rowserrcheck
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unused
-    - varcheck
+    - sloglint
+    - stylecheck
+    - tagalign
+    - tagliatelle
+    - tenv
+    - testableexamples
+    - testifylint
+    - thelper
+    - tparallel
+    # - unconvert
+    - unparam
+    - usestdlibvars
+    - wastedassign
+    - whitespace
+    - zerologlint


### PR DESCRIPTION
Starting with all linters, I have removed those that are inappropriate or infeasible entirely.  The linters that are commented out are aspirational -- they may require a lot of effort, or changes to the public API.

- golangci: update linter list
- use newer version of golangci-lint

Closes #320 