### PR TITLE
fix!: rename mediatype.MediaTypeParseOptions to remove repetition

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - contextcheck
     - decorder
     # - dupl
-    # - dupword
     - durationcheck
     - errchkjson
     - errname
@@ -56,7 +55,7 @@ linters:
     - promlinter
     - protogetter
     - reassign
-    # - revive
+    - revive
     - rowserrcheck
     - sloglint
     - stylecheck

--- a/boundary.go
+++ b/boundary.go
@@ -180,7 +180,7 @@ func (b *boundaryReader) Next() (bool, error) {
 		_, _ = io.Copy(io.Discard, b)
 	}
 	for {
-		var line []byte = nil
+		var line []byte
 		var err error
 		for {
 			// Read whole line, handle extra long lines in cycle

--- a/builder_test.go
+++ b/builder_test.go
@@ -592,7 +592,7 @@ func TestBuilderAddAttachment(t *testing.T) {
 		"text/html",
 		"image/jpeg",
 	}
-	gotParts := root.DepthMatchAll(func(p *enmime.Part) bool { return true })
+	gotParts := root.DepthMatchAll(func(_ *enmime.Part) bool { return true })
 	gotTypes := make([]string, 0)
 	for _, p := range gotParts {
 		gotTypes = append(gotTypes, p.ContentType)
@@ -734,7 +734,7 @@ func TestBuilderAddInline(t *testing.T) {
 		"text/html",
 		"image/jpeg",
 	}
-	gotParts := root.DepthMatchAll(func(p *enmime.Part) bool { return true })
+	gotParts := root.DepthMatchAll(func(_ *enmime.Part) bool { return true })
 	gotTypes := make([]string, 0)
 	for _, p := range gotParts {
 		gotTypes = append(gotTypes, p.ContentType)
@@ -878,7 +878,7 @@ func TestBuilderAddOtherPart(t *testing.T) {
 		"text/html",
 		"image/jpeg",
 	}
-	gotParts := root.DepthMatchAll(func(p *enmime.Part) bool { return true })
+	gotParts := root.DepthMatchAll(func(_ *enmime.Part) bool { return true })
 	gotTypes := make([]string, 0)
 	for _, p := range gotParts {
 		contentType := p.ContentType
@@ -1016,7 +1016,7 @@ func TestBuilderFullStructure(t *testing.T) {
 		"multipart/related > image/png",
 		"multipart/mixed > image/jpeg",
 	}
-	gotParts := root.DepthMatchAll(func(p *enmime.Part) bool { return true })
+	gotParts := root.DepthMatchAll(func(_ *enmime.Part) bool { return true })
 	gotTypes := make([]string, 0)
 	for _, p := range gotParts {
 		pct := ""

--- a/cmd/mime-extractor/mime-extractor_test.go
+++ b/cmd/mime-extractor/mime-extractor_test.go
@@ -84,7 +84,7 @@ func TestExtractFailedToParse(t *testing.T) {
 
 func TestExtractAttachmentWriteFail(t *testing.T) {
 	s := &bytes.Buffer{}
-	fw := func(filename string, data []byte, perm os.FileMode) error {
+	fw := func(_ string, _ []byte, _ os.FileMode) error {
 		return errors.New("AttachmentWriteFail")
 	}
 	testExtractor := &extractor{
@@ -105,7 +105,7 @@ func TestExtractAttachmentWriteFail(t *testing.T) {
 func TestExtractSuccess(t *testing.T) {
 	b := &bytes.Buffer{}
 	attachmentCount := 0
-	fw := func(filename string, data []byte, perm os.FileMode) error {
+	fw := func(_ string, _ []byte, _ os.FileMode) error {
 		attachmentCount++
 		return nil
 	}

--- a/mediatype/mediatype.go
+++ b/mediatype/mediatype.go
@@ -30,8 +30,8 @@ const (
 	utf8 = "utf-8"
 )
 
-// MediaTypeParseOptions controls the parsing of content-type and media-type strings.
-type MediaTypeParseOptions struct {
+// ParseOptions controls the parsing of content-type and media-type strings.
+type ParseOptions struct {
 	StripMediaTypeInvalidCharacters bool
 }
 
@@ -43,11 +43,11 @@ type MediaTypeParseOptions struct {
 //   - Unquoted values in media parameters containing 'tspecials' characters
 //   - Newline characters
 func Parse(ctype string) (mtype string, params map[string]string, invalidParams []string, err error) {
-	return ParseWithOptions(ctype, MediaTypeParseOptions{})
+	return ParseWithOptions(ctype, ParseOptions{})
 }
 
 // ParseWithOptions parses media-type with additional options controlling the parsing behavior.
-func ParseWithOptions(ctype string, options MediaTypeParseOptions) (mtype string, params map[string]string, invalidParams []string, err error) {
+func ParseWithOptions(ctype string, options ParseOptions) (mtype string, params map[string]string, invalidParams []string, err error) {
 	mtype, params, err = mime.ParseMediaType(
 		fixNewlines(fixUnescapedQuotes(fixUnquotedSpecials(fixMangledMediaType(removeTrailingHTMLTags(ctype), ';', options)))))
 	if err != nil {
@@ -73,7 +73,7 @@ func ParseWithOptions(ctype string, options MediaTypeParseOptions) (mtype string
 
 // fixMangledMediaType is used to insert ; separators into media type strings that lack them, and
 // remove repeated parameters.
-func fixMangledMediaType(mtype string, sep rune, options MediaTypeParseOptions) string {
+func fixMangledMediaType(mtype string, sep rune, options ParseOptions) string {
 	strsep := string([]rune{sep})
 	if mtype == "" {
 		return ""

--- a/mediatype/mediatype_test.go
+++ b/mediatype/mediatype_test.go
@@ -9,7 +9,7 @@ func TestFixMangledMediaType(t *testing.T) {
 		input   string
 		sep     rune
 		want    string
-		options MediaTypeParseOptions
+		options ParseOptions
 	}{
 		{
 			input: "",
@@ -145,7 +145,7 @@ func TestFixMangledMediaType(t *testing.T) {
 			input:   `text/html>`,
 			sep:     ';',
 			want:    `text/html`,
-			options: MediaTypeParseOptions{StripMediaTypeInvalidCharacters: true},
+			options: ParseOptions{StripMediaTypeInvalidCharacters: true},
 		},
 	}
 	for _, tc := range testCases {

--- a/options_test.go
+++ b/options_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSetCustomParseMediaType(t *testing.T) {
-	alwaysReturnHTML := func(ctype string) (mtype string, params map[string]string, invalidParams []string, err error) {
+	alwaysReturnHTML := func(_ string) (mtype string, params map[string]string, invalidParams []string, err error) {
 		return "text/html", nil, nil, err
 	}
 	changeAndUtilizeDefault := func(ctype string) (mtype string, params map[string]string, invalidParams []string, err error) {

--- a/part.go
+++ b/part.go
@@ -333,7 +333,7 @@ func (p *Part) decodeContent(r io.Reader, readPartErrorPolicy ReadPartErrorPolic
 // parses media type using custom or default media type parser
 func (p *Part) parseMediaType(ctype string) (mtype string, params map[string]string, invalidParams []string, err error) {
 	if p.parser == nil || p.parser.customParseMediaType == nil {
-		return mediatype.ParseWithOptions(ctype, mediatype.MediaTypeParseOptions{StripMediaTypeInvalidCharacters: p.parser.stripMediaTypeInvalidCharacters})
+		return mediatype.ParseWithOptions(ctype, mediatype.ParseOptions{StripMediaTypeInvalidCharacters: p.parser.stripMediaTypeInvalidCharacters})
 	}
 
 	return p.parser.customParseMediaType(ctype)

--- a/part_test.go
+++ b/part_test.go
@@ -37,7 +37,7 @@ func TestPlainTextPart(t *testing.T) {
 	test.ContentContainsString(t, p.Content, want)
 }
 
-func TestAddChildInfiniteLoops(t *testing.T) {
+func TestAddChildInfiniteLoops(_ *testing.T) {
 	// Part adds itself
 	parentPart := &enmime.Part{
 		ContentType: "text/plain",
@@ -440,7 +440,7 @@ func TestReadPartErrorPolicy(t *testing.T) {
 	})
 
 	// example policy 3: always recover the partial content read, no matter the error
-	examplePolicy3 := enmime.ReadPartErrorPolicy(func(p *enmime.Part, err error) bool {
+	examplePolicy3 := enmime.ReadPartErrorPolicy(func(_ *enmime.Part, _ error) bool {
 		return true
 	})
 


### PR DESCRIPTION
Renamed to `mediatype.ParseOptions`.  It is a breaking change, but the repetition forced us to keep some linters disabled.

Also resolve a number of warnings for re-enabled `revive` linter.