### PR TITLE
chore: bump nix deps, remove deprecated golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ simplify:
 
 lint:
 	@test -z "$(shell gofmt -l . | tee /dev/stderr)" || echo "[WARN] Fix formatting issues with 'make fmt'"
-	@# TODO: lint disabled until `mediatype.MediaTypeParseOptions` renamed to remove repetition.
-	@#@golint -set_exit_status $(PKGS)
 	@go vet $(PKGS)
 
 reflex:

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702272962,
-        "narHash": "sha256-D+zHwkwPc6oYQ4G3A1HuadopqRwUY/JkMwHz1YF7j4Q=",
+        "lastModified": 1725099143,
+        "narHash": "sha256-CHgumPZaC7z+WYx72WgaLt2XF0yUVzJS60rO4GZ7ytY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d",
+        "rev": "5629520edecb69630a3f4d17d3d33fc96c13f6fe",
         "type": "github"
       },
       "original": {

--- a/shell.nix
+++ b/shell.nix
@@ -2,8 +2,8 @@
 pkgs.mkShell {
   buildInputs = with pkgs; [
     delve
-    go_1_20
-    golint
+    go
+    golangci-lint
     gopls
   ];
 


### PR DESCRIPTION
Signed-off-by: James Hillyerd <james@hillyerd.com>
