### PR TITLE
chore: bump min go version to 1.20

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.18.x
-          - 1.19.x
           - 1.20.x
+          - 1.21.x
+          - 1.22.x
     name: Go ${{ matrix.go }} build
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jhillyerd/enmime
 
-go 1.18
+go 1.20
 
 require (
 	github.com/cention-sany/utf7 v0.0.0-20170124080048-26cad61bd60a


### PR DESCRIPTION
Signed-off-by: James Hillyerd <james@hillyerd.com>
