### PR TITLE
chore!: remove deprecated MaxPartErrors global var

### DIFF
--- a/error.go
+++ b/error.go
@@ -27,12 +27,6 @@ const (
 	ErrorMalformedChildPart = "Malformed child part"
 )
 
-// MaxPartErrors limits number of part parsing errors, errors after the limit are ignored.
-// 0 means unlimited.
-//
-// Deprecated: This limit may be set via the `MaxStoredPartErrors` Parser option.
-var MaxPartErrors = 0
-
 // Error describes an error encountered while parsing.
 type Error struct {
 	Name   string // The name or type of error encountered, from Error consts.
@@ -84,10 +78,10 @@ func (p *Part) addWarningf(name string, detailFmt string, args ...interface{}) {
 
 // addProblem adds general *Error to the Part error slice.
 func (p *Part) addProblem(err *Error) {
-	maxErrors := MaxPartErrors
-	if p.parser != nil && p.parser.maxStoredPartErrors != nil {
+	maxErrors := 0
+	if p.parser != nil {
 		// Override global var.
-		maxErrors = *p.parser.maxStoredPartErrors
+		maxErrors = p.parser.maxStoredPartErrors
 	}
 
 	if (maxErrors == 0) || (len(p.Errors) < maxErrors) {

--- a/error_test.go
+++ b/error_test.go
@@ -133,53 +133,7 @@ func TestErrorEnvelopeWarnings(t *testing.T) {
 	}
 }
 
-// Deprecated.
-func TestErrorLimit(t *testing.T) {
-	// Backup global variable
-	originalMaxPartErros := MaxPartErrors
-	defer func() {
-		MaxPartErrors = originalMaxPartErros
-	}()
-
-	addThreeErrors := func() int {
-		part := NewPart("text/plain")
-		part.addError("test1", "test1")
-		part.addError("test2", "test2")
-		part.addError("test3", "test3")
-
-		return len(part.Errors)
-	}
-
-	// Check unlimited
-	var errCount int
-	MaxPartErrors = 0
-	errCount = addThreeErrors()
-	if errCount != 3 {
-		t.Errorf("Expected unlimited errors (3), got %d", errCount)
-	}
-
-	// Check limit
-	MaxPartErrors = 1
-	errCount = addThreeErrors()
-	if errCount != 1 {
-		t.Errorf("Expected limited errors (1), got %d", errCount)
-	}
-
-	// Check limit matching count
-	MaxPartErrors = 3
-	errCount = addThreeErrors()
-	if errCount != 3 {
-		t.Errorf("Expected limited errors (3), got %d", errCount)
-	}
-}
-
 func TestErrorLimitOption(t *testing.T) {
-	// Backup global variable
-	originalMaxPartErros := MaxPartErrors
-	defer func() {
-		MaxPartErrors = originalMaxPartErros
-	}()
-
 	addThreeErrors := func(parser *Parser) int {
 		part := NewPart("text/plain")
 		if parser != nil {
@@ -204,13 +158,6 @@ func TestErrorLimitOption(t *testing.T) {
 	want = 3
 	got = addThreeErrors(NewParser())
 	assert.Equal(t, want, got, "expected unlimited errors")
-
-	// Check the default actually comes from deprecated MaxPartErrors global.
-	want = 1
-	MaxPartErrors = want
-	got = addThreeErrors(nil)
-	assert.Equal(t, want, got, "expected limited errors")
-	MaxPartErrors = 0
 
 	// Check limit.
 	want = 1

--- a/options.go
+++ b/options.go
@@ -48,8 +48,7 @@ func MaxStoredPartErrors(n int) Option {
 type maxStoredPartErrorsOption int
 
 func (o maxStoredPartErrorsOption) apply(p *Parser) {
-	n := int(o)
-	p.maxStoredPartErrors = &n
+	p.maxStoredPartErrors = int(o)
 }
 
 // RawContent if set to true will not try to decode the CTE and return the raw part content.

--- a/parser.go
+++ b/parser.go
@@ -18,7 +18,7 @@ type CustomParseMediaType func(ctype string) (mtype string, params map[string]st
 
 // Parser parses MIME.  Create with NewParser to inherit recommended defaults.
 type Parser struct {
-	maxStoredPartErrors             *int // TODO: Pointer until global var removed.
+	maxStoredPartErrors             int
 	multipartWOBoundaryAsSinglePart bool
 	readPartErrorPolicy             ReadPartErrorPolicy
 	skipMalformedParts              bool


### PR DESCRIPTION
Use `MaxStoredPartErrors` parser option instead
