### PR TITLE
chore!: remove deprecated Error.String method

### DIFF
--- a/error.go
+++ b/error.go
@@ -43,11 +43,6 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("[%s] %s: %s", sev, e.Name, e.Detail)
 }
 
-// String formats the enmime.Error as a string. DEPRECATED; use Error() instead.
-func (e *Error) String() string {
-	return e.Error()
-}
-
 // addError builds a severe Error and appends to the Part error slice.
 func (p *Part) addError(name string, detail string) {
 	p.addProblem(&Error{name, detail, true})

--- a/error_test.go
+++ b/error_test.go
@@ -27,9 +27,8 @@ func TestErrorStringConversion(t *testing.T) {
 		Severe: true,
 	}
 
-	// Using deprecated String() method here for test coverage
 	want = "[E] ErrorName: Error Details"
-	got = e.String()
+	got = e.Error()
 	if got != want {
 		t.Error("got:", got, "want:", want)
 	}


### PR DESCRIPTION
Use Error.Error() instead
