### PR TITLE
Tests: TestRandOption fail

### DIFF
--- a/randoption_test.go
+++ b/randoption_test.go
@@ -77,6 +77,7 @@ func buildEmail(t *testing.T, mode ReproducibilityMode) string {
 		b = enmime.Builder()
 	case TimestampSource:
 		b = enmime.Builder().RandSeed(time.Now().UTC().UnixNano())
+		time.Sleep(1)
 	default:
 		panic(fmt.Errorf("illegal mode: %d", mode))
 	}

--- a/randoption_test.go
+++ b/randoption_test.go
@@ -77,7 +77,7 @@ func buildEmail(t *testing.T, mode ReproducibilityMode) string {
 		b = enmime.Builder()
 	case TimestampSource:
 		b = enmime.Builder().RandSeed(time.Now().UTC().UnixNano())
-		time.Sleep(1)
+		time.Sleep(time.Microsecond)
 	default:
 		panic(fmt.Errorf("illegal mode: %d", mode))
 	}


### PR DESCRIPTION
What I did:

run tests with `go test enmime`

What I got:

`--- FAIL: TestRandOption (0.00s)
    randoption_test.go:22`

Release or branch I am using:

2.0.0