### PR TITLE
chore: bump golangci to last 1.x release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.3
+          version: v1.64.8


### PR DESCRIPTION
Signed-off-by: James Hillyerd <james@hillyerd.com>
