### PR TITLE
chore: bump golangci to 2.x

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,6 @@ jobs:
           go-version: 1.23
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.8
+          version: v2.0.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,4 @@
-run:
-  timeout: 5m
+version: "2"
 linters:
   enable:
     - asasalint
@@ -10,28 +9,17 @@ linters:
     - contextcheck
     - copyloopvar
     - decorder
-    # - dupl
     - durationcheck
     - errchkjson
     - errname
-    # - errorlint
-    # - exhaustive
-    # - forcetypeassert
     - ginkgolinter
     - gocheckcompilerdirectives
-    # - gochecknoinits
     - gochecksumtype
     - gocritic
-    # - godot
-    # - goerr113
-    - gofmt
-    # - gofumpt
     - goheader
-    - goimports
     - gomoddirectives
     - gomodguard
     - goprintffuncname
-    # - gosec
     - gosmopolitan
     - grouper
     - importas
@@ -43,8 +31,6 @@ linters:
     - misspell
     - musttag
     - nilerr
-    # - nilnil
-    # - nlreturn
     - noctx
     - nolintlint
     - nosprintfhostport
@@ -57,17 +43,41 @@ linters:
     - revive
     - rowserrcheck
     - sloglint
-    - stylecheck
+    - staticcheck
     - tagalign
     - tagliatelle
-    - tenv
     - testableexamples
     - testifylint
     - thelper
     - tparallel
-    # - unconvert
     - unparam
     - usestdlibvars
     - wastedassign
     - whitespace
     - zerologlint
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+    rules:
+      # Exclude specific linters from test files.
+      - path: _test\.go
+        linters:
+          - gosmopolitan
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Signed-off-by: James Hillyerd <james@hillyerd.com>
