### PR TITLE
feat!: Refactor EnvelopeFromPart()'s scope

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -175,7 +175,7 @@ func (p Parser) ReadEnvelope(r io.Reader) (*Envelope, error) {
 
 // EnvelopeFromPart uses the provided Part tree to build an Envelope, downconverting HTML to plain
 // text if needed, and sorting the attachments, inlines and other parts into their respective
-// slices.  Errors are collected from all Parts and placed into the Envelopes Errors slice.
+// slices.  Gather errors from all parts with Envelope.GatherNestedErrors().
 func EnvelopeFromPart(root *Part) (*Envelope, error) {
 	return defaultParser.EnvelopeFromPart(root)
 }

--- a/envelope.go
+++ b/envelope.go
@@ -159,7 +159,18 @@ func (p Parser) ReadEnvelope(r io.Reader) (*Envelope, error) {
 	if err != nil {
 		return nil, errors.WithMessage(err, "Failed to ReadParts")
 	}
-	return p.EnvelopeFromPart(root)
+
+	e, err := p.EnvelopeFromPart(root)
+	if err != nil {
+		return nil, errors.WithMessage(err, "Failed to EnvelopeFromPart")
+	}
+
+	err = e.GatherNestedErrors()
+	if err != nil {
+		return nil, errors.WithMessage(err, "Failed to GatherNestedErrors")
+	}
+
+	return e, nil
 }
 
 // EnvelopeFromPart uses the provided Part tree to build an Envelope, downconverting HTML to plain
@@ -210,7 +221,12 @@ func (p Parser) EnvelopeFromPart(root *Part) (*Envelope, error) {
 		}
 	}
 
-	// Copy part errors into Envelope.
+	return e, nil
+}
+
+// GatherNestedErrors gathers errors from the entire part tree (including the root) and adds them to the Envelope.
+func (e *Envelope) GatherNestedErrors() error {
+	// Copy part errors from all nested/child/sibling parts into Envelope.
 	if e.Root != nil {
 		_ = e.Root.DepthMatchAll(func(part *Part) bool {
 			// Using DepthMatchAll to traverse all parts, don't care about result.
@@ -219,7 +235,7 @@ func (p Parser) EnvelopeFromPart(root *Part) (*Envelope, error) {
 		})
 	}
 
-	return e, nil
+	return nil
 }
 
 // parseTextOnlyBody parses a plain text message in root that has MIME-like headers, but

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -74,11 +74,6 @@ func TestParseNonMimeHTML(t *testing.T) {
 			t.Errorf("e.Errors[0] got: %v, want: %v", got, want)
 		}
 	} else {
-		for _, err = range e.Errors {
-			fmt.Println(err.Error())
-			fmt.Println(enmime.ErrorPlainTextFromHTML)
-
-		}
 		t.Errorf("len(e.Errors) got: %v, want: 1", len(e.Errors))
 	}
 

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -61,6 +61,7 @@ func TestParseNonMime(t *testing.T) {
 
 func TestParseNonMimeHTML(t *testing.T) {
 	msg := test.OpenTestData("mail", "non-mime-html.raw")
+
 	e, err := enmime.ReadEnvelope(msg)
 
 	if err != nil {
@@ -73,6 +74,11 @@ func TestParseNonMimeHTML(t *testing.T) {
 			t.Errorf("e.Errors[0] got: %v, want: %v", got, want)
 		}
 	} else {
+		for _, err = range e.Errors {
+			fmt.Println(err.Error())
+			fmt.Println(enmime.ErrorPlainTextFromHTML)
+
+		}
 		t.Errorf("len(e.Errors) got: %v, want: 1", len(e.Errors))
 	}
 
@@ -84,6 +90,57 @@ func TestParseNonMimeHTML(t *testing.T) {
 	want = "<span>This</span>"
 	if !strings.Contains(e.HTML, want) {
 		t.Errorf("Expected %q to contain %q", e.HTML, want)
+	}
+}
+
+// TestEnvelopeFromPartDoesNotGatherErrors verifies that EnvelopeFromPart does not collect errors,
+// while GatherNestedErrors does. This enforces the separation of concerns: EnvelopeFromPart builds
+// the envelope structure, and GatherNestedErrors is responsible for error collection.
+func TestEnvelopeFromPartDoesNotGatherErrors(t *testing.T) {
+	// Use a message that generates errors (HTML without plain text)
+	msg := test.OpenTestData("mail", "non-mime-html.raw")
+	parser := enmime.NewParser()
+	root, err := parser.ReadParts(msg)
+	if err != nil {
+		t.Fatalf("Failed to read parts: %v", err)
+	}
+
+	// Call EnvelopeFromPart directly (not ReadEnvelope)
+	e, err := parser.EnvelopeFromPart(root)
+	if err != nil {
+		t.Fatalf("Failed to create envelope from part: %v", err)
+	}
+
+	// EnvelopeFromPart should NOT have collected errors
+	if len(e.Errors) != 0 {
+		t.Errorf("EnvelopeFromPart should not gather errors, but got %d errors:", len(e.Errors))
+		for _, err := range e.Errors {
+			t.Logf("  - %v", err)
+		}
+	}
+
+	// Verify that the envelope structure was built correctly
+	if e.HTML == "" {
+		t.Error("Expected HTML content from envelope structure building")
+	}
+
+	// Now call GatherNestedErrors
+	err = e.GatherNestedErrors()
+	if err != nil {
+		t.Fatalf("GatherNestedErrors failed: %v", err)
+	}
+
+	// GatherNestedErrors SHOULD have collected the error
+	if len(e.Errors) != 1 {
+		t.Errorf("GatherNestedErrors should collect exactly 1 error, got %d", len(e.Errors))
+	} else if e.Errors[0].Name != enmime.ErrorPlainTextFromHTML {
+		t.Errorf("Expected error %q, got %q", enmime.ErrorPlainTextFromHTML, e.Errors[0].Name)
+	}
+
+	// Verify text was downconverted from HTML
+	want := "This is *a* *test* mailing"
+	if !strings.Contains(e.Text, want) {
+		t.Errorf("Expected %q to contain %q", e.Text, want)
 	}
 }
 


### PR DESCRIPTION
### Summary
Refactor EnvelopeFromPart()'s scope so that the functions's scope of work is more aligned to the root aspect of a provided part:

- Extracted the functionality from EnvelopeFromPart which gathered errors from any/all nested/child/sibling parts into a new method on enmime.Envelope called GatherNestedErrors(). GatherNestedErrors() is also implemented in ReadEnvelope().
- Also extracted the previous functionality into a new method on the Envelope type - GatherNestedErrors(). Also implemented GatherNestedErrors() within ReadEnvelope() after the call to EnvelopeFromPart() and added supporting test cases.

### Why
The scope of the current form of EnvelopeFromPart is inconsistant in that the function's supposed purpose is to create a header from the root of a provided part, but the concluding body of the current form of EnvelopeFromPart() gathering errors from any/all nested/child/sibling parts. This is an effort to clarify the scope of work of EnvelopeFromPart to focus on any single part.

### Testing
All current tests pass, and because the new method GatherNestedErrors() is also called ReadEnvelope(), ReadEnvelope()'s tests cover the GatherNestedErrors().

#### Note:
This is me actually following through on #372 - Better late than never.