### PR TITLE
Add ContentTransferEncoding field to force CTE on a Part

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -45,13 +45,24 @@ func (p *Part) Encode(writer io.Writer) error {
 		p.Header = make(textproto.MIMEHeader)
 	}
 	if p.ContentReader != nil {
-		// read some data in order to check whether the content is empty
-		p.Content = make([]byte, readChunkSize)
-		n, err := p.ContentReader.Read(p.Content)
-		if err != nil && err != io.EOF {
-			return err
+		// When a forced CTE is set to something other than base64, we need the full content
+		// in memory to use the standard encode path (not the streaming base64 path).
+		if forced := p.resolveForcedCTE(); forced != teRaw && forced != teBase64 {
+			all, err := io.ReadAll(p.ContentReader)
+			if err != nil {
+				return err
+			}
+			p.Content = all
+			p.ContentReader = nil
+		} else {
+			// read some data in order to check whether the content is empty
+			p.Content = make([]byte, readChunkSize)
+			n, err := p.ContentReader.Read(p.Content)
+			if err != nil && err != io.EOF {
+				return err
+			}
+			p.Content = p.Content[:n]
 		}
-		p.Content = p.Content[:n]
 	}
 	cte := teRaw
 	if p.parser == nil || !p.parser.rawContent {
@@ -108,8 +119,13 @@ func (p *Part) setupMIMEHeaders() transferEncoding {
 	p.Header.Del(hnContentEncoding)
 
 	cte := te7Bit
+	forcedCTE := false
 	if len(p.Content) > 0 {
-		if strings.Index(strings.ToLower(p.ContentType), "message/") == 0 {
+		// Check for explicit override first.
+		if f := p.resolveForcedCTE(); f != teRaw {
+			cte = f
+			forcedCTE = true
+		} else if strings.Index(strings.ToLower(p.ContentType), "message/") == 0 {
 			// RFC 1341: `message` types must have no encoding other than "7bit", "8bit", or
 			// "binary". The message header fields are always US-ASCII in any case, and data within
 			// the body can still be encoded, in which case the Content-Transfer-Encoding header
@@ -127,6 +143,10 @@ func (p *Part) setupMIMEHeaders() transferEncoding {
 
 		// RFC 2045: 7bit is assumed if CTE header not present.
 		switch cte {
+		case te7Bit:
+			if forcedCTE {
+				p.Header.Set(hnContentEncoding, cte7Bit)
+			}
 		case te8Bit:
 			p.Header.Set(hnContentEncoding, cte8Bit)
 		case teBase64:
@@ -296,6 +316,24 @@ func (p *Part) encodeContentFromReader(b *bufio.Writer) error {
 	}
 
 	return nil
+}
+
+// resolveForcedCTE maps the ContentTransferEncoding field to an internal transferEncoding
+// value. Returns teRaw (sentinel for "not set / unrecognised") when the field is empty or
+// contains an unrecognised value.
+func (p *Part) resolveForcedCTE() transferEncoding {
+	switch strings.ToLower(p.ContentTransferEncoding) {
+	case cte7Bit:
+		return te7Bit
+	case cte8Bit:
+		return te8Bit
+	case cteQuotedPrintable:
+		return teQuoted
+	case cteBase64:
+		return teBase64
+	default:
+		return teRaw // sentinel: no override
+	}
 }
 
 // selectTransferEncoding scans content for non-ASCII characters and selects 'b' or 'q' encoding.

--- a/encode_test.go
+++ b/encode_test.go
@@ -462,6 +462,190 @@ func TestParseRawContentTextOptionFalse(t *testing.T) {
 	test.DiffGolden(t, b.Bytes(), "testdata", "encode", "parser-raw-content-text-option-false.raw.golden")
 }
 
+// TestEncodePartForcedCTE7Bit verifies that a non-text part with 7bit-safe content and forced "7bit" CTE
+// is not base64-encoded and the header reads Content-Transfer-Encoding: 7bit.
+func TestEncodePartForcedCTE7Bit(t *testing.T) {
+	p := enmime.NewPart("application/pgp-encrypted")
+	p.ContentTransferEncoding = "7bit"
+	p.Content = []byte("Version: 1")
+
+	b := &bytes.Buffer{}
+	err := p.Encode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "7bit", p.Header.Get("Content-Transfer-Encoding"))
+	assert.Contains(t, b.String(), "Version: 1")
+	assert.NotContains(t, b.String(), "base64")
+}
+
+// TestEncodePartForcedCTEQuotedPrintable verifies QP encoding is applied when forced.
+func TestEncodePartForcedCTEQuotedPrintable(t *testing.T) {
+	p := enmime.NewPart("application/pgp-signature")
+	p.ContentTransferEncoding = "quoted-printable"
+	p.Content = []byte("-----BEGIN PGP SIGNATURE-----\r\nVersion: GnuPG\r\n\r\n=AAAA\r\n-----END PGP SIGNATURE-----")
+
+	b := &bytes.Buffer{}
+	err := p.Encode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "quoted-printable", p.Header.Get("Content-Transfer-Encoding"))
+	assert.Contains(t, b.String(), "-----BEGIN PGP")
+}
+
+// TestEncodePartForcedCTEBase64 verifies base64 is applied when explicitly forced.
+func TestEncodePartForcedCTEBase64(t *testing.T) {
+	p := enmime.NewPart("application/zip")
+	p.ContentTransferEncoding = "base64"
+	p.Content = []byte("ZIPZIPZIP")
+
+	b := &bytes.Buffer{}
+	err := p.Encode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "base64", p.Header.Get("Content-Transfer-Encoding"))
+}
+
+// TestEncodePartForcedCTE8Bit verifies 8bit header is set and content is written verbatim.
+func TestEncodePartForcedCTE8Bit(t *testing.T) {
+	p := enmime.NewPart("application/octet-stream")
+	p.ContentTransferEncoding = "8bit"
+	p.Content = []byte("some binary data")
+
+	b := &bytes.Buffer{}
+	err := p.Encode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "8bit", p.Header.Get("Content-Transfer-Encoding"))
+	assert.Contains(t, b.String(), "some binary data")
+}
+
+// TestEncodePartForcedCTEEmpty verifies empty ContentTransferEncoding preserves default behavior (base64 for non-text).
+func TestEncodePartForcedCTEEmpty(t *testing.T) {
+	p := enmime.NewPart("application/octet-stream")
+	p.ContentTransferEncoding = ""
+	p.Content = []byte("data")
+
+	b := &bytes.Buffer{}
+	err := p.Encode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "base64", p.Header.Get("Content-Transfer-Encoding"))
+}
+
+// TestEncodePartForcedCTEUnrecognised verifies unrecognised values fall back to automatic detection.
+func TestEncodePartForcedCTEUnrecognised(t *testing.T) {
+	p := enmime.NewPart("application/octet-stream")
+	p.ContentTransferEncoding = "unknown-encoding"
+	p.Content = []byte("data")
+
+	b := &bytes.Buffer{}
+	err := p.Encode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Non-text part should default to base64.
+	assert.Equal(t, "base64", p.Header.Get("Content-Transfer-Encoding"))
+}
+
+// TestEncodePartForcedCTECaseInsensitive verifies case-insensitive matching.
+func TestEncodePartForcedCTECaseInsensitive(t *testing.T) {
+	for _, val := range []string{"7Bit", "7BIT", "7bit"} {
+		p := enmime.NewPart("application/pgp-encrypted")
+		p.ContentTransferEncoding = val
+		p.Content = []byte("Version: 1")
+
+		b := &bytes.Buffer{}
+		err := p.Encode(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, "7bit", p.Header.Get("Content-Transfer-Encoding"),
+			"expected 7bit for input %q", val)
+	}
+
+	for _, val := range []string{"BASE64", "Base64", "base64"} {
+		p := enmime.NewPart("text/plain")
+		p.ContentTransferEncoding = val
+		p.Content = []byte("hello")
+
+		b := &bytes.Buffer{}
+		err := p.Encode(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, "base64", p.Header.Get("Content-Transfer-Encoding"),
+			"expected base64 for input %q", val)
+	}
+}
+
+// TestEncodePartForcedCTETextPartBase64 verifies that forcing base64 on a text part
+// overrides the auto-detection that would normally pick 7bit or QP.
+func TestEncodePartForcedCTETextPartBase64(t *testing.T) {
+	p := enmime.NewPart("text/plain")
+	p.ContentTransferEncoding = "base64"
+	p.Content = []byte("Hello, this is plain ASCII text that would normally be 7bit.")
+
+	b := &bytes.Buffer{}
+	err := p.Encode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "base64", p.Header.Get("Content-Transfer-Encoding"))
+	// Should not contain the plaintext directly
+	assert.NotContains(t, b.String(), "Hello, this is plain ASCII")
+}
+
+// TestEncodePartForcedCTEWithContentReader verifies that ContentReader + forced 7bit CTE
+// writes content verbatim instead of base64-encoding it.
+func TestEncodePartForcedCTEWithContentReader(t *testing.T) {
+	content := []byte("Version: 1")
+	p := enmime.NewPart("application/pgp-encrypted")
+	p.ContentTransferEncoding = "7bit"
+	p.ContentReader = bytes.NewReader(content)
+
+	b := &bytes.Buffer{}
+	err := p.Encode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "7bit", p.Header.Get("Content-Transfer-Encoding"))
+	assert.Contains(t, b.String(), "Version: 1")
+	assert.Nil(t, p.ContentReader, "ContentReader should have been consumed")
+}
+
+// TestEncodePartForcedCTEPrecedenceOverEncoderOption verifies that ContentTransferEncoding on the part
+// takes precedence over the encoder-level ForceQuotedPrintableCte option.
+func TestEncodePartForcedCTEPrecedenceOverEncoderOption(t *testing.T) {
+	p := enmime.NewPart("application/octet-stream").WithEncoder(
+		enmime.NewEncoder(enmime.ForceQuotedPrintableCte(true)),
+	)
+	p.ContentTransferEncoding = "7bit"
+	p.Content = []byte("plain ASCII data")
+
+	b := &bytes.Buffer{}
+	err := p.Encode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Part-level override should win over encoder option.
+	assert.Equal(t, "7bit", p.Header.Get("Content-Transfer-Encoding"))
+	assert.Contains(t, b.String(), "plain ASCII data")
+}
+
 // TestRawContentUTF8Headers verifies plain-text headers are unmodified with the rawContent parser option.
 func TestRawContentUTF8Headers(t *testing.T) {
 	r := test.OpenTestData("encode", "utf8-to.raw.golden")

--- a/part.go
+++ b/part.go
@@ -42,6 +42,12 @@ type Part struct {
 	Charset           string            // The content charset encoding, may differ from charset in header.
 	OrigCharset       string            // The original content charset when a different charset was detected.
 
+	// ContentTransferEncoding forces the Content-Transfer-Encoding header to the specified
+	// value when encoding this part. Valid values are "7bit", "8bit", "base64", and
+	// "quoted-printable". When empty, the encoding is selected automatically.
+	// Unrecognised values fall back to automatic detection.
+	ContentTransferEncoding string
+
 	Errors        []*Error  // Errors encountered while parsing this part.
 	Content       []byte    // Content after decoding, UTF-8 conversion if applicable.
 	ContentReader io.Reader // Reader interface for pulling the content for encoding.
@@ -372,18 +378,19 @@ func (p *Part) Clone(parent *Part) *Part {
 	}
 
 	newPart := &Part{
-		PartID:      p.PartID,
-		Header:      p.Header,
-		Parent:      parent,
-		Boundary:    p.Boundary,
-		ContentID:   p.ContentID,
-		ContentType: p.ContentType,
-		Disposition: p.Disposition,
-		FileName:    p.FileName,
-		Charset:     p.Charset,
-		Errors:      p.Errors,
-		Content:     p.Content,
-		Epilogue:    p.Epilogue,
+		PartID:                  p.PartID,
+		Header:                  p.Header,
+		Parent:                  parent,
+		Boundary:                p.Boundary,
+		ContentID:               p.ContentID,
+		ContentType:             p.ContentType,
+		Disposition:             p.Disposition,
+		FileName:                p.FileName,
+		Charset:                 p.Charset,
+		ContentTransferEncoding: p.ContentTransferEncoding,
+		Errors:                  p.Errors,
+		Content:                 p.Content,
+		Epilogue:                p.Epilogue,
 	}
 	newPart.FirstChild = p.FirstChild.Clone(newPart)
 	newPart.NextSibling = p.NextSibling.Clone(parent)
@@ -515,5 +522,12 @@ func (p *Part) WithEncoder(e *Encoder) *Part {
 	if e != nil {
 		p.encoder = e
 	}
+	return p
+}
+
+// SetContentTransferEncoding sets the ContentTransferEncoding field on this Part,
+// forcing the specified Content-Transfer-Encoding when encoding.
+func (p *Part) SetContentTransferEncoding(cte string) *Part {
+	p.ContentTransferEncoding = cte
 	return p
 }

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,163 @@
+# Plan: Allow Forcing Content-Transfer-Encoding on a Part
+
+**Issue:** [#395](https://github.com/jhillyerd/enmime/issues/395)  
+**Approach:** Option 2 — Add a `ContentTransferEncoding` field to `Part`
+
+## Problem
+
+`setupMIMEHeaders()` in `encode.go` defaults to `teBase64` for all non-text content types, bypassing `selectTransferEncoding()` entirely. This means ASCII-safe content like PGP armor (`application/pgp-encrypted`, `application/pgp-signature`) is unnecessarily base64-encoded, with no way for the caller to override.
+
+## Changes
+
+### 1. Add field to `Part` struct — `part.go`
+
+```go
+type Part struct {
+    // ... existing fields ...
+
+    // ContentTransferEncoding forces the Content-Transfer-Encoding header to the specified
+    // value when encoding this part. Valid values are "7bit", "8bit", "base64", and
+    // "quoted-printable". When empty, the encoding is selected automatically.
+    // Unrecognised values fall back to automatic detection.
+    ContentTransferEncoding string
+}
+```
+
+This is consistent with the existing pattern of exported string fields like `Charset`, `Boundary`, `ContentID`, etc.
+
+### 2. Respect the field in `setupMIMEHeaders()` — `encode.go`
+
+Modify the content transfer encoding selection block (lines ~108–135) to check `p.ContentTransferEncoding` **before** the automatic detection logic:
+
+```go
+cte := te7Bit
+if len(p.Content) > 0 {
+    // Check for explicit override first.
+    if forced := p.resolveForcedCTE(); forced != teRaw {
+        cte = forced
+    } else if strings.Index(strings.ToLower(p.ContentType), "message/") == 0 {
+        cte = te8Bit
+    } else {
+        cte = teBase64
+        if p.TextContent() && p.ContentReader == nil {
+            cte = p.selectTransferEncoding(p.Content, false)
+            if p.Charset == "" {
+                p.Charset = utf8
+            }
+        }
+    }
+    // ... existing header.Set switch ...
+}
+```
+
+The override takes precedence over both `TextContent()` gating and `Encoder.ForceQuotedPrintableCte`, since it is the most specific (per-part) directive. `ContentReader` parts can also be overridden (currently they are hardcoded to base64 via `encodeContentFromReader`).
+
+### 3. Add helper to resolve forced CTE — `encode.go`
+
+```go
+// resolveForcedCTE maps the ContentTransferEncoding field to an internal transferEncoding
+// value. Returns teRaw (sentinel for "not set / unrecognised") when the field is empty or
+// contains an unrecognised value.
+func (p *Part) resolveForcedCTE() transferEncoding {
+    switch strings.ToLower(p.ContentTransferEncoding) {
+    case cte7Bit:
+        return te7Bit
+    case cte8Bit:
+        return te8Bit
+    case cteQuotedPrintable:
+        return teQuoted
+    case cteBase64:
+        return teBase64
+    default:
+        return teRaw // sentinel: no override
+    }
+}
+```
+
+Using `teRaw` as the "not set" sentinel avoids introducing a new sentinel type, since `teRaw` is not a valid CTE value and is already used elsewhere for a similar "passthrough" meaning.
+
+### 4. Handle `encodeContent` for non-base64 with `ContentReader` — `encode.go`
+
+Currently `encodeContentFromReader` always base64-encodes. When a forced CTE of `te7Bit`, `te8Bit`, or `teQuoted` is used with a `ContentReader`, we need to either:
+
+- **Option A (recommended):** Read all content from the reader into `p.Content` and use the standard `encodeContent` path. This is simple and correct. The caller forcing a CTE on a streaming part is an unusual case.
+- **Option B:** Add streaming encode paths for QP and passthrough. Adds complexity for minimal benefit.
+
+For the initial implementation, go with Option A: if `ContentReader != nil` and the forced CTE is not base64, slurp the reader into `p.Content` in `Encode()` before calling `setupMIMEHeaders()`, and set `ContentReader = nil`.
+
+### 5. Add `WithContentTransferEncoding` on `MailBuilder` — `builder.go`
+
+So users of the builder API can set the encoding on attachment/inline parts. Add a method to `Part` and a corresponding `MailBuilder` method to set it when adding parts.
+
+On `Part`:
+
+```go
+// SetContentTransferEncoding sets the ContentTransferEncoding field.
+func (p *Part) SetContentTransferEncoding(cte string) *Part {
+    p.ContentTransferEncoding = cte
+    return p
+}
+```
+
+This mirrors the existing `WithEncoder()` builder-style pattern on `Part`.
+
+No changes to `MailBuilder` itself in the initial PR — callers can set it on the `*Part` before passing it to `AddAttachmentPart()` / `AddInlinePart()`. A `MailBuilder` convenience method can be added later if demand exists.
+
+## Tests — `encode_test.go`
+
+Add the following test cases:
+
+1. **Non-text part with 7bit-safe content, CTE forced to `"7bit"`**  
+   Verify no base64 encoding is applied and the header reads `Content-Transfer-Encoding: 7bit`.
+
+2. **Non-text part with CTE forced to `"quoted-printable"`**  
+   Verify QP encoding is applied.
+
+3. **Non-text part with CTE forced to `"base64"`**  
+   Verify base64 is applied (same as default behavior).
+
+4. **Non-text part with CTE forced to `"8bit"`**  
+   Verify 8bit header is set and content is written verbatim.
+
+5. **Non-text part with empty `ContentTransferEncoding`**  
+   Verify existing default behavior (base64) is preserved.
+
+6. **Non-text part with unrecognised `ContentTransferEncoding` value**  
+   Verify fallback to automatic detection (base64 for non-text).
+
+7. **Case-insensitive values**  
+   Verify `"7Bit"`, `"BASE64"`, etc. all work.
+
+8. **Text part with CTE forced to `"base64"`**  
+   Verify that the override takes precedence over auto-detection (which would normally pick 7bit or QP for ASCII content).
+
+9. **Part with `ContentReader` and forced `"7bit"` CTE**  
+   Verify content is written verbatim (not base64-encoded).
+
+10. **Interaction with `ForceQuotedPrintableCte` Encoder option**  
+    Verify that `ContentTransferEncoding` on the part takes precedence over the encoder-level option.
+
+## Interaction with existing features
+
+| Feature | Interaction |
+|---|---|
+| `Encoder.ForceQuotedPrintableCte` | `ContentTransferEncoding` on the part takes precedence (more specific) |
+| `TextContent()` gate | Bypassed when `ContentTransferEncoding` is set — this is the whole point |
+| `ContentReader` (streaming) | If forced CTE ≠ base64, reader is slurped into `Content`; if base64, streaming path is unchanged |
+| `rawContent` parser option | `rawContent` bypasses `setupMIMEHeaders()` entirely, so no interaction |
+| `message/*` RFC 1341 special case | `ContentTransferEncoding` override takes precedence; caller is responsible for RFC compliance |
+| Parsed parts (round-trip) | `ContentTransferEncoding` is a new field, defaults to `""`, so parsed parts behave exactly as before |
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `part.go` | Add `ContentTransferEncoding string` field; add `SetContentTransferEncoding()` method |
+| `encode.go` | Add `resolveForcedCTE()`; modify `setupMIMEHeaders()` and `Encode()` to respect the field; handle `ContentReader` + non-base64 CTE |
+| `encode_test.go` | Add test cases listed above |
+
+## Out of scope
+
+- Changing the automatic detection heuristics for non-text types (could be a separate enhancement)
+- Adding a `MailBuilder`-level convenience method for setting CTE on attachments
+- Validation that content actually fits the forced encoding (e.g., non-ASCII in 7bit) — follows Python's precedent of raising errors here, but we'll defer that


### PR DESCRIPTION
Allows callers to override the automatic Content-Transfer-Encoding
selection on a per-part basis. Valid values are "7bit", "8bit",
"base64", and "quoted-printable". Empty or unrecognised values
fall back to automatic detection.

This is useful for ASCII-safe content like PGP armor
(application/pgp-encrypted, application/pgp-signature) that would
otherwise be unnecessarily base64-encoded.

The forced CTE takes precedence over both the TextContent() gate
and the Encoder.ForceQuotedPrintableCte option.

Closes #395
