### PR TITLE
fix: decouple internal/textproto from net/textproto error types

### DIFF
--- a/inspect_test.go
+++ b/inspect_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"io"
 	"net/mail"
-	"net/textproto"
 	"strings"
 	"testing"
 
 	"github.com/jhillyerd/enmime/v2"
 	"github.com/jhillyerd/enmime/v2/internal/test"
+	"github.com/jhillyerd/enmime/v2/internal/textproto"
 )
 
 func TestDecodeRFC2047(t *testing.T) {

--- a/internal/textproto/reader.go
+++ b/internal/textproto/reader.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net/textproto"
 	"strconv"
 	"strings"
 	"sync"
@@ -200,20 +199,20 @@ func (r *Reader) readCodeLine(expectCode int) (code int, continued bool, message
 
 func parseCodeLine(line string, expectCode int) (code int, continued bool, message string, err error) {
 	if len(line) < 4 || line[3] != ' ' && line[3] != '-' {
-		err = textproto.ProtocolError("short response: " + line)
+		err = ProtocolError("short response: " + line)
 		return
 	}
 	continued = line[3] == '-'
 	code, err = strconv.Atoi(line[0:3])
 	if err != nil || code < 100 {
-		err = textproto.ProtocolError("invalid response code: " + line)
+		err = ProtocolError("invalid response code: " + line)
 		return
 	}
 	message = line[4:]
 	if 1 <= expectCode && expectCode < 10 && code/100 != expectCode ||
 		10 <= expectCode && expectCode < 100 && code/10 != expectCode ||
 		100 <= expectCode && expectCode < 1000 && code != expectCode {
-		err = &textproto.Error{Code: code, Msg: message}
+		err = &Error{Code: code, Msg: message}
 	}
 	return
 }
@@ -238,7 +237,7 @@ func parseCodeLine(line string, expectCode int) (code int, continued bool, messa
 func (r *Reader) ReadCodeLine(expectCode int) (code int, message string, err error) {
 	code, continued, message, err := r.readCodeLine(expectCode)
 	if err == nil && continued {
-		err = textproto.ProtocolError("unexpected multi-line response: " + message)
+		err = ProtocolError("unexpected multi-line response: " + message)
 	}
 	return
 }
@@ -295,7 +294,7 @@ func (r *Reader) ReadResponse(expectCode int) (code int, message string, err err
 	message = messageBuilder.String()
 	if err != nil && multi && message != "" {
 		// replace one line error message with all lines (full message)
-		err = &textproto.Error{Code: code, Msg: message}
+		err = &Error{Code: code, Msg: message}
 	}
 	return
 }
@@ -513,7 +512,7 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		if err != nil {
 			return m, err
 		}
-		return m, textproto.ProtocolError("malformed MIME header initial line: " + string(line))
+		return m, ProtocolError("malformed MIME header initial line: " + string(line))
 	}
 
 	for {
@@ -525,15 +524,15 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		// Key ends at first colon.
 		k, v, ok := bytes.Cut(kv, colon)
 		if !ok {
-			return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError("malformed MIME header line: " + string(kv))
 		}
 		key, ok := canonicalMIMEHeaderKey(k)
 		if !ok {
-			return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError("malformed MIME header line: " + string(kv))
 		}
 		for _, c := range v {
 			if !validHeaderValueByte(c) {
-				return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
+				return m, ProtocolError("malformed MIME header line: " + string(kv))
 			}
 		}
 
@@ -585,7 +584,7 @@ func noValidation(_ []byte) error { return nil }
 // contain a colon.
 func mustHaveFieldNameColon(line []byte) error {
 	if bytes.IndexByte(line, ':') < 0 {
-		return textproto.ProtocolError(fmt.Sprintf("malformed MIME header: missing colon: %q", line))
+		return ProtocolError(fmt.Sprintf("malformed MIME header: missing colon: %q", line))
 	}
 	return nil
 }

--- a/internal/textproto/reader_email.go
+++ b/internal/textproto/reader_email.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"math"
-	"net/textproto"
 )
 
 // ReadEmailMIMEHeader reads a MIME-style header from r.
@@ -33,7 +32,7 @@ func readEmailMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		if err != nil {
 			return m, err
 		}
-		return m, textproto.ProtocolError("malformed MIME header initial line: " + string(line))
+		return m, ProtocolError("malformed MIME header initial line: " + string(line))
 	}
 
 	for {
@@ -45,11 +44,11 @@ func readEmailMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		// Key ends at first colon.
 		k, v, ok := bytes.Cut(kv, colon)
 		if !ok {
-			return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError("malformed MIME header line: " + string(kv))
 		}
 		key, ok := canonicalEmailMIMEHeaderKey(k)
 		if !ok {
-			return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError("malformed MIME header line: " + string(kv))
 		}
 		// for _, c := range v {
 		// 	if !validHeaderValueByte(c) {

--- a/internal/textproto/reader_test.go
+++ b/internal/textproto/reader_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"io"
 	"net"
-	"net/textproto"
 	"reflect"
 	"strings"
 	"sync"
@@ -70,7 +69,7 @@ func TestReadCodeLine(t *testing.T) {
 	if code != 345 || msg != "no way" || err == nil {
 		t.Fatalf("Line 3: %d, %s, %v", code, msg, err)
 	}
-	if e, ok := err.(*textproto.Error); !ok || e.Code != code || e.Msg != msg {
+	if e, ok := err.(*Error); !ok || e.Code != code || e.Msg != msg {
 		t.Fatalf("Line 3: wrong error %v\n", err)
 	}
 	code, msg, err = r.ReadCodeLine(1)

--- a/internal/textproto/textproto.go
+++ b/internal/textproto/textproto.go
@@ -27,9 +27,34 @@ package textproto
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"net"
 )
+
+// An Error represents a numeric error response from a server.
+//
+// We define this locally rather than using net/textproto.Error to insulate
+// ourselves from upstream formatting changes (e.g. Go 1.26 CVE-2026-42507).
+type Error struct {
+	Code int
+	Msg  string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%03d %s", e.Code, e.Msg)
+}
+
+// A ProtocolError describes a protocol violation such as an invalid response
+// or a hung-up connection.
+//
+// We define this locally rather than using net/textproto.ProtocolError to
+// insulate ourselves from upstream formatting changes (e.g. Go 1.26 CVE-2026-42507).
+type ProtocolError string
+
+func (p ProtocolError) Error() string {
+	return string(p)
+}
 
 // A Conn represents a textual network protocol connection.
 // It consists of a Reader and Writer to manage I/O


### PR DESCRIPTION
The vendored `internal/textproto` package was importing `net/textproto` and delegating to its `ProtocolError` and `Error` types. This defeated the purpose of vendoring — Go 1.26's [CVE-2026-42507](https://go-review.googlesource.com/c/go/+/777060) changed `Error.Error()` to `fmt.Sprintf("%03d %q", ...)` (quoting Msg), breaking test expectations at `reader_test.go:329`.

**Changes:**
- Define local `ProtocolError` and `Error` types in `internal/textproto/textproto.go` with the original stable formatting.
- Remove all `"net/textproto"` imports from `reader.go`, `reader_email.go`, and `reader_test.go`, replacing qualified references with the local types.
- Update `inspect_test.go` to import the internal package instead of `net/textproto` for the `ProtocolError` type assertion.

Compatible with all Go versions. Fix verified against Go 1.26.4.

NB: This is just a break-fix to make sure enmime can build on newer Go versions.  I'll make another PR to actually fix the CVE, but that may be considered an API change.