### PR TITLE
fix: apply CVE-2026-42507 escaping to internal/textproto

### DIFF
--- a/inspect_test.go
+++ b/inspect_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"io"
 	"net/mail"
-	"net/textproto"
 	"strings"
 	"testing"
 
 	"github.com/jhillyerd/enmime/v2"
 	"github.com/jhillyerd/enmime/v2/internal/test"
+	"github.com/jhillyerd/enmime/v2/internal/textproto"
 )
 
 func TestDecodeRFC2047(t *testing.T) {

--- a/internal/textproto/reader.go
+++ b/internal/textproto/reader.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net/textproto"
 	"strconv"
 	"strings"
 	"sync"
@@ -200,20 +199,20 @@ func (r *Reader) readCodeLine(expectCode int) (code int, continued bool, message
 
 func parseCodeLine(line string, expectCode int) (code int, continued bool, message string, err error) {
 	if len(line) < 4 || line[3] != ' ' && line[3] != '-' {
-		err = textproto.ProtocolError("short response: " + line)
+		err = ProtocolError(fmt.Sprintf("short response: %q", line))
 		return
 	}
 	continued = line[3] == '-'
 	code, err = strconv.Atoi(line[0:3])
 	if err != nil || code < 100 {
-		err = textproto.ProtocolError("invalid response code: " + line)
+		err = ProtocolError(fmt.Sprintf("invalid response code: %q", line))
 		return
 	}
 	message = line[4:]
 	if 1 <= expectCode && expectCode < 10 && code/100 != expectCode ||
 		10 <= expectCode && expectCode < 100 && code/10 != expectCode ||
 		100 <= expectCode && expectCode < 1000 && code != expectCode {
-		err = &textproto.Error{Code: code, Msg: message}
+		err = &Error{Code: code, Msg: message}
 	}
 	return
 }
@@ -238,7 +237,7 @@ func parseCodeLine(line string, expectCode int) (code int, continued bool, messa
 func (r *Reader) ReadCodeLine(expectCode int) (code int, message string, err error) {
 	code, continued, message, err := r.readCodeLine(expectCode)
 	if err == nil && continued {
-		err = textproto.ProtocolError("unexpected multi-line response: " + message)
+		err = ProtocolError(fmt.Sprintf("unexpected multi-line response: %q", message))
 	}
 	return
 }
@@ -295,7 +294,7 @@ func (r *Reader) ReadResponse(expectCode int) (code int, message string, err err
 	message = messageBuilder.String()
 	if err != nil && multi && message != "" {
 		// replace one line error message with all lines (full message)
-		err = &textproto.Error{Code: code, Msg: message}
+		err = &Error{Code: code, Msg: message}
 	}
 	return
 }
@@ -513,7 +512,7 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		if err != nil {
 			return m, err
 		}
-		return m, textproto.ProtocolError("malformed MIME header initial line: " + string(line))
+		return m, ProtocolError(fmt.Sprintf("malformed MIME header initial line: %q", line))
 	}
 
 	for {
@@ -525,15 +524,15 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		// Key ends at first colon.
 		k, v, ok := bytes.Cut(kv, colon)
 		if !ok {
-			return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError(fmt.Sprintf("malformed MIME header line: %q", kv))
 		}
 		key, ok := canonicalMIMEHeaderKey(k)
 		if !ok {
-			return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError(fmt.Sprintf("malformed MIME header line: %q", kv))
 		}
 		for _, c := range v {
 			if !validHeaderValueByte(c) {
-				return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
+				return m, ProtocolError(fmt.Sprintf("malformed MIME header line: %q", kv))
 			}
 		}
 
@@ -585,7 +584,7 @@ func noValidation(_ []byte) error { return nil }
 // contain a colon.
 func mustHaveFieldNameColon(line []byte) error {
 	if bytes.IndexByte(line, ':') < 0 {
-		return textproto.ProtocolError(fmt.Sprintf("malformed MIME header: missing colon: %q", line))
+		return ProtocolError(fmt.Sprintf("malformed MIME header: missing colon: %q", line))
 	}
 	return nil
 }

--- a/internal/textproto/reader_email.go
+++ b/internal/textproto/reader_email.go
@@ -3,8 +3,8 @@ package textproto
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math"
-	"net/textproto"
 )
 
 // ReadEmailMIMEHeader reads a MIME-style header from r.
@@ -33,7 +33,7 @@ func readEmailMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		if err != nil {
 			return m, err
 		}
-		return m, textproto.ProtocolError("malformed MIME header initial line: " + string(line))
+		return m, ProtocolError(fmt.Sprintf("malformed MIME header initial line: %q", line))
 	}
 
 	for {
@@ -45,11 +45,11 @@ func readEmailMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		// Key ends at first colon.
 		k, v, ok := bytes.Cut(kv, colon)
 		if !ok {
-			return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError(fmt.Sprintf("malformed MIME header line: %q", kv))
 		}
 		key, ok := canonicalEmailMIMEHeaderKey(k)
 		if !ok {
-			return m, textproto.ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError(fmt.Sprintf("malformed MIME header line: %q", kv))
 		}
 		// for _, c := range v {
 		// 	if !validHeaderValueByte(c) {

--- a/internal/textproto/reader_test.go
+++ b/internal/textproto/reader_test.go
@@ -7,9 +7,9 @@ package textproto
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"net"
-	"net/textproto"
 	"reflect"
 	"strings"
 	"sync"
@@ -70,7 +70,7 @@ func TestReadCodeLine(t *testing.T) {
 	if code != 345 || msg != "no way" || err == nil {
 		t.Fatalf("Line 3: %d, %s, %v", code, msg, err)
 	}
-	if e, ok := err.(*textproto.Error); !ok || e.Code != code || e.Msg != msg {
+	if e, ok := err.(*Error); !ok || e.Code != code || e.Msg != msg {
 		t.Fatalf("Line 3: wrong error %v\n", err)
 	}
 	code, msg, err = r.ReadCodeLine(1)
@@ -349,8 +349,8 @@ func TestReadMultiLineError(t *testing.T) {
 	if msg != wantMsg {
 		t.Errorf("ReadResponse: msg=%q, want %q", msg, wantMsg)
 	}
-	if err != nil && err.Error() != "550 "+wantMsg {
-		t.Errorf("ReadResponse: error=%q, want %q", err.Error(), "550 "+wantMsg)
+	if err != nil && err.Error() != fmt.Sprintf("550 %q", wantMsg) {
+		t.Errorf("ReadResponse: error=%q, want %q", err.Error(), fmt.Sprintf("550 %q", wantMsg))
 	}
 }
 

--- a/internal/textproto/textproto.go
+++ b/internal/textproto/textproto.go
@@ -27,9 +27,34 @@ package textproto
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"net"
 )
+
+// An Error represents a numeric error response from a server.
+//
+// We define this locally rather than using net/textproto.Error to insulate
+// ourselves from upstream formatting changes (e.g. Go 1.26 CVE-2026-42507).
+type Error struct {
+	Code int
+	Msg  string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%03d %q", e.Code, e.Msg)
+}
+
+// A ProtocolError describes a protocol violation such as an invalid response
+// or a hung-up connection.
+//
+// We define this locally rather than using net/textproto.ProtocolError to
+// insulate ourselves from upstream formatting changes (e.g. Go 1.26 CVE-2026-42507).
+type ProtocolError string
+
+func (p ProtocolError) Error() string {
+	return string(p)
+}
 
 // A Conn represents a textual network protocol connection.
 // It consists of a Reader and Writer to manage I/O


### PR DESCRIPTION
Follow-up to #397. Now that we have local `ProtocolError` and `Error` types, apply the same CVE-2026-42507 fix that upstream applied in Go 1.26 ([CL 777060](https://go-review.googlesource.com/c/go/+/777060)):

- `Error.Error()` now quotes `Msg` via `%q` to prevent injection of misleading content or terminal control bytes
- All `ProtocolError` messages that include user-controlled input now use `fmt.Sprintf` with `%q` instead of raw string concatenation

This ensures enmime is not a vector for the vulnerability regardless of which Go version it is built with.