### PR TITLE
fix: escape arbitrary input in textproto errors (CVE-2026-42507)

### DIFF
--- a/internal/textproto/reader.go
+++ b/internal/textproto/reader.go
@@ -199,13 +199,13 @@ func (r *Reader) readCodeLine(expectCode int) (code int, continued bool, message
 
 func parseCodeLine(line string, expectCode int) (code int, continued bool, message string, err error) {
 	if len(line) < 4 || line[3] != ' ' && line[3] != '-' {
-		err = ProtocolError("short response: " + line)
+		err = ProtocolError(fmt.Sprintf("short response: %q", line))
 		return
 	}
 	continued = line[3] == '-'
 	code, err = strconv.Atoi(line[0:3])
 	if err != nil || code < 100 {
-		err = ProtocolError("invalid response code: " + line)
+		err = ProtocolError(fmt.Sprintf("invalid response code: %q", line))
 		return
 	}
 	message = line[4:]
@@ -237,7 +237,7 @@ func parseCodeLine(line string, expectCode int) (code int, continued bool, messa
 func (r *Reader) ReadCodeLine(expectCode int) (code int, message string, err error) {
 	code, continued, message, err := r.readCodeLine(expectCode)
 	if err == nil && continued {
-		err = ProtocolError("unexpected multi-line response: " + message)
+		err = ProtocolError(fmt.Sprintf("unexpected multi-line response: %q", message))
 	}
 	return
 }
@@ -512,7 +512,7 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		if err != nil {
 			return m, err
 		}
-		return m, ProtocolError("malformed MIME header initial line: " + string(line))
+		return m, ProtocolError(fmt.Sprintf("malformed MIME header initial line: %q", line))
 	}
 
 	for {
@@ -524,15 +524,15 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		// Key ends at first colon.
 		k, v, ok := bytes.Cut(kv, colon)
 		if !ok {
-			return m, ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError(fmt.Sprintf("malformed MIME header line: %q", kv))
 		}
 		key, ok := canonicalMIMEHeaderKey(k)
 		if !ok {
-			return m, ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError(fmt.Sprintf("malformed MIME header line: %q", kv))
 		}
 		for _, c := range v {
 			if !validHeaderValueByte(c) {
-				return m, ProtocolError("malformed MIME header line: " + string(kv))
+				return m, ProtocolError(fmt.Sprintf("malformed MIME header line: %q", kv))
 			}
 		}
 

--- a/internal/textproto/reader_email.go
+++ b/internal/textproto/reader_email.go
@@ -3,6 +3,7 @@ package textproto
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math"
 )
 
@@ -32,7 +33,7 @@ func readEmailMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		if err != nil {
 			return m, err
 		}
-		return m, ProtocolError("malformed MIME header initial line: " + string(line))
+		return m, ProtocolError(fmt.Sprintf("malformed MIME header initial line: %q", line))
 	}
 
 	for {
@@ -44,11 +45,11 @@ func readEmailMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
 		// Key ends at first colon.
 		k, v, ok := bytes.Cut(kv, colon)
 		if !ok {
-			return m, ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError(fmt.Sprintf("malformed MIME header line: %q", kv))
 		}
 		key, ok := canonicalEmailMIMEHeaderKey(k)
 		if !ok {
-			return m, ProtocolError("malformed MIME header line: " + string(kv))
+			return m, ProtocolError(fmt.Sprintf("malformed MIME header line: %q", kv))
 		}
 		// for _, c := range v {
 		// 	if !validHeaderValueByte(c) {

--- a/internal/textproto/reader_test.go
+++ b/internal/textproto/reader_test.go
@@ -7,6 +7,7 @@ package textproto
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"net"
 	"reflect"
@@ -348,8 +349,8 @@ func TestReadMultiLineError(t *testing.T) {
 	if msg != wantMsg {
 		t.Errorf("ReadResponse: msg=%q, want %q", msg, wantMsg)
 	}
-	if err != nil && err.Error() != "550 "+wantMsg {
-		t.Errorf("ReadResponse: error=%q, want %q", err.Error(), "550 "+wantMsg)
+	if err != nil && err.Error() != fmt.Sprintf("550 %q", wantMsg) {
+		t.Errorf("ReadResponse: error=%q, want %q", err.Error(), fmt.Sprintf("550 %q", wantMsg))
 	}
 }
 

--- a/internal/textproto/textproto.go
+++ b/internal/textproto/textproto.go
@@ -42,7 +42,7 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("%03d %s", e.Code, e.Msg)
+	return fmt.Sprintf("%03d %q", e.Code, e.Msg)
 }
 
 // A ProtocolError describes a protocol violation such as an invalid response


### PR DESCRIPTION
Follow-up to #397. Apply the same CVE-2026-42507 fix that upstream applied in Go 1.26 ([CL 777060](https://go-review.googlesource.com/c/go/+/777060)):

- `Error.Error()` now quotes `Msg` via `%q` to prevent injection of misleading content or terminal control bytes
- All `ProtocolError` messages that include user-controlled input now use `fmt.Sprintf` with `%q` instead of raw string concatenation

This ensures enmime is not a vector for the vulnerability regardless of which Go version it is built with.