### PR TITLE
Ensuring returned `error`s include a stack

### DIFF
--- a/boundary.go
+++ b/boundary.go
@@ -223,7 +223,7 @@ func (b *boundaryReader) Next() (bool, error) {
 			continue
 		}
 		b.finished = true
-		return false, errors.WithMessagef(errNoBoundaryTerminator, "expecting boundary %q, got %q", string(b.prefix), string(line))
+		return false, errors.Wrapf(errNoBoundaryTerminator, "expecting boundary %q, got %q", string(b.prefix), string(line))
 	}
 }
 

--- a/builder.go
+++ b/builder.go
@@ -2,7 +2,6 @@ package enmime
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"maps"
 	"math/rand"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"github.com/jhillyerd/enmime/v2/internal/stringutil"
+	"github.com/pkg/errors"
 )
 
 // MailBuilder facilitates the easy construction of a MIME message.  Each manipulation method

--- a/dsn/parse.go
+++ b/dsn/parse.go
@@ -3,12 +3,11 @@ package dsn
 import (
 	"bufio"
 	"bytes"
-	"errors"
-	"fmt"
 	"io"
 
 	"github.com/jhillyerd/enmime/v2"
 	"github.com/jhillyerd/enmime/v2/internal/textproto"
+	"github.com/pkg/errors"
 )
 
 // ParseReport parses p as a "container" for delivery status report (per rfc6522) if p is "multipart/report".
@@ -90,7 +89,7 @@ func setExplanation(e *Explanation, p *enmime.Part) bool {
 func parseDeliveryStatus(data []byte) (DeliveryStatus, error) {
 	fields, err := parseDeliveryStatusFields(data)
 	if err != nil {
-		return DeliveryStatus{}, fmt.Errorf("parse delivery status: %w", err)
+		return DeliveryStatus{}, errors.WithMessage(err, "parse delivery status")
 	}
 
 	perMessage, perRecipient := splitDSNFields(fields)
@@ -124,7 +123,7 @@ func parseDeliveryStatusFields(data []byte) ([]textproto.MIMEHeader, error) {
 				break
 			}
 
-			return nil, fmt.Errorf("read MIME header fields: %w", err)
+			return nil, errors.Wrap(err, "read MIME header fields")
 		}
 
 		fields = append(fields, h)

--- a/envelope.go
+++ b/envelope.go
@@ -1,7 +1,6 @@
 package enmime
 
 import (
-	"fmt"
 	"io"
 	"mime"
 	"net/mail"
@@ -109,7 +108,7 @@ func (e *Envelope) AddressList(key string) ([]*mail.Address, error) {
 		return nil, errors.New("no headers available")
 	}
 	if !AddressHeaders[strings.ToLower(key)] {
-		return nil, fmt.Errorf("%s is not an address header", key)
+		return nil, errors.Errorf("%s is not an address header", key)
 	}
 
 	return ParseAddressList(e.header.Get(key))
@@ -282,10 +281,10 @@ func parseMultiPartBody(root *Part, e *Envelope) error {
 	ctype := root.Header.Get(hnContentType)
 	mediatype, params, _, err := root.parseMediaType(ctype)
 	if err != nil {
-		return fmt.Errorf("unable to parse media type: %v", err)
+		return errors.WithMessage(err, "unable to parse media type")
 	}
 	if !strings.HasPrefix(mediatype, ctMultipartPrefix) {
-		return fmt.Errorf("unknown mediatype: %v", mediatype)
+		return errors.Errorf("unknown mediatype: %v", mediatype)
 	}
 	boundary := params[hpBoundary]
 	if boundary == "" {

--- a/internal/coding/base64.go
+++ b/internal/coding/base64.go
@@ -1,8 +1,9 @@
 package coding
 
 import (
-	"fmt"
 	"io"
+
+	"github.com/pkg/errors"
 )
 
 // base64CleanerTable notes byte values that should be stripped (-2), stripped w/ error (-1).
@@ -51,7 +52,7 @@ func (bc *Base64Cleaner) Read(p []byte) (n int, err error) {
 			// Strip these silently: tab, \n, \r, space, equals sign.
 		case -1:
 			// Strip these, but warn the client.
-			bc.Errors = append(bc.Errors, fmt.Errorf("unexpected %q in base64 stream", buf[i]))
+			bc.Errors = append(bc.Errors, errors.Errorf("unexpected %q in base64 stream", buf[i]))
 		default:
 			p[n] = buf[i]
 			n++

--- a/internal/coding/charsets.go
+++ b/internal/coding/charsets.go
@@ -2,12 +2,12 @@ package coding
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"regexp"
 	"strings"
 
 	"github.com/cention-sany/utf7"
+	"github.com/pkg/errors"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/charmap"
 	"golang.org/x/text/encoding/japanese"
@@ -302,7 +302,7 @@ func init() {
 func ConvertToUTF8String(charset string, textBytes []byte) (string, error) {
 	csentry, ok := encodings[strings.ToLower(charset)]
 	if !ok {
-		return "", fmt.Errorf("unsupported charset %q", charset)
+		return "", errors.Errorf("unsupported charset %q", charset)
 	}
 	input := bytes.NewReader(textBytes)
 	reader := transform.NewReader(input, csentry.e.NewDecoder())
@@ -323,7 +323,7 @@ func NewCharsetReader(charset string, input io.Reader) (io.Reader, error) {
 	}
 	csentry, ok := encodings[strings.ToLower(charset)]
 	if !ok {
-		return nil, fmt.Errorf("unsupported charset %q", charset)
+		return nil, errors.Errorf("unsupported charset %q", charset)
 	}
 	return transform.NewReader(input, csentry.e.NewDecoder()), nil
 }

--- a/mediatype/mediatype.go
+++ b/mediatype/mediatype.go
@@ -69,7 +69,7 @@ func ParseWithOptions(ctype string, options ParseOptions) (mtype string, params 
 		delete(params, name)
 	}
 
-	return mtype, params, invalidParams, err
+	return mtype, params, invalidParams, nil
 }
 
 // fixMangledMediaType is used to insert ; separators into media type strings that lack them, and


### PR DESCRIPTION
Some returned errors didn't include stacks, making it more challenging to find where things weren't going right.

Now they do.