### PR TITLE
mediatype: dedup parameters by exact name, not substring

### DIFF
--- a/mediatype/mediatype.go
+++ b/mediatype/mediatype.go
@@ -82,6 +82,7 @@ func fixMangledMediaType(mtype string, sep rune, options ParseOptions) string {
 
 	parts := stringutil.SplitUnquoted(mtype, sep, '"')
 	mtype = ""
+	seen := map[string]bool{}
 	if strings.Contains(parts[0], "=") {
 		// A parameter pair at this position indicates we are missing a content-type.
 		parts[0] = fmt.Sprintf("%s%s %s", ctAppOctetStream, strsep, parts[0])
@@ -143,8 +144,10 @@ func fixMangledMediaType(mtype string, sep rune, options ParseOptions) string {
 				continue
 			}
 
-			if strings.Contains(mtype, strings.TrimSpace(pair[0])) {
-				// Ignore repeated parameters.
+			// Ignore repeated parameters. Compare exact param names
+			// case-insensitively (RFC 2045 §5.1), not by substring (#162).
+			key := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(pair[0], "=")))
+			if seen[key] {
 				continue
 			}
 
@@ -154,6 +157,8 @@ func fixMangledMediaType(mtype string, sep rune, options ParseOptions) string {
 				// attribute.  Discard the pair.
 				continue
 			}
+
+			seen[key] = true
 		}
 
 		mtype += p

--- a/mediatype/mediatype_test.go
+++ b/mediatype/mediatype_test.go
@@ -122,6 +122,26 @@ func TestFixMangledMediaType(t *testing.T) {
 			sep:   ';',
 			want:  `one/two; name="file.two"`,
 		},
+		{
+			// Keeps a distinct param whose name is a suffix of an earlier
+			// one (previously dropped by the substring match) (#162).
+			input: `application/octet-stream; filename="a.txt"; name="b.txt"`,
+			sep:   ';',
+			want:  `application/octet-stream; filename="a.txt"; name="b.txt"`,
+		},
+		{
+			// Keeps a distinct param whose "key=" appears inside an earlier
+			// param's value (#162).
+			input: `text/plain; note="size=5"; size="10"`,
+			sep:   ';',
+			want:  `text/plain; note="size=5"; size="10"`,
+		},
+		{
+			// Duplicate param names are case-insensitive (RFC 2045 §5.1).
+			input: `text/plain; name="x"; NAME="y"`,
+			sep:   ';',
+			want:  `text/plain; name="x"`,
+		},
 
 		// remove extra content type parts
 		{
@@ -522,6 +542,30 @@ func TestParseMediaType(t *testing.T) {
 			input:  "application/pdf; name=\"=?iso-8859-1?Q?key=3Dvalue?=\"",
 			mtype:  "application/pdf",
 			params: map[string]string{"name": "key=value"},
+		},
+		{
+			label:  "distinct suffix-name param kept",
+			input:  `application/octet-stream; filename="a.txt"; name="b.txt"`,
+			mtype:  "application/octet-stream",
+			params: map[string]string{"filename": "a.txt", "name": "b.txt"},
+		},
+		{
+			label:  "distinct param whose key appears in earlier value kept",
+			input:  `text/plain; note="size=5"; size="10"`,
+			mtype:  "text/plain",
+			params: map[string]string{"note": "size=5", "size": "10"},
+		},
+		{
+			label:  "exact duplicate keeps first",
+			input:  `text/plain; name="first"; name="second"`,
+			mtype:  "text/plain",
+			params: map[string]string{"name": "first"},
+		},
+		{
+			label:  "case-insensitive duplicate keeps first",
+			input:  `text/plain; name="x"; NAME="y"`,
+			mtype:  "text/plain",
+			params: map[string]string{"name": "x"},
 		},
 	}
 	for _, tc := range testCases {

--- a/part_test.go
+++ b/part_test.go
@@ -37,6 +37,23 @@ func TestPlainTextPart(t *testing.T) {
 	test.ContentContainsString(t, p.Content, want)
 }
 
+func TestContentTypeSuffixParamNotDropped(t *testing.T) {
+	// "name" carries the attachment filename and must not be dropped just
+	// because "name=" is a substring of the earlier "xname=" param (#162).
+	r := strings.NewReader("Content-Type: application/octet-stream; xname=\"detail\"; name=\"report.pdf\"\r\n" +
+		"\r\nbody\r\n")
+	p, err := enmime.ReadParts(r)
+	if err != nil {
+		t.Fatalf("Unexpected parse error: %+v", err)
+	}
+	if p == nil {
+		t.Fatal("Root node should not be nil")
+	}
+	if got, want := p.FileName, "report.pdf"; got != want {
+		t.Errorf("FileName got %q, want %q", got, want)
+	}
+}
+
 func TestAddChildInfiniteLoops(_ *testing.T) {
 	// Part adds itself
 	parentPart := &enmime.Part{


### PR DESCRIPTION
`fixMangledMediaType` deduplicates media-type parameters (added for #162) with a substring test:

```go
if strings.Contains(mtype, strings.TrimSpace(pair[0])) { // pair[0] == "name="
    continue
}
```

`mtype` is the parameter section accumulated so far, so a *distinct* parameter is dropped whenever its `"<name>="` token appears in the earlier text — usually when the name is a suffix of an earlier one (`name` after `filename`, `id` after `uuid`, `type` after `subtype`), or when `"<name>="` occurs inside an earlier value. Since `filename` and `name` co-occur in most attachment headers, `application/octet-stream; filename="a"; name="b"` loses `name` and the attachment filename is silently discarded.

These are all well-formed RFC 2045 headers that Go's `mime.ParseMediaType` returns intact, so it's a clean oracle for the intended result:

```
application/octet-stream; filename="a.txt"; name="b.txt"   -> name dropped
text/x; uuid="u"; id="7"                                    -> id dropped
text/plain; note="size=5"; size="10"                        -> size dropped
```

Fix: track seen parameter names in an exact, case-insensitive set (RFC 2045 §5.1 makes names case-insensitive) and skip only true duplicate keys. Exact repeats still collapse (the #162 behavior); distinct parameters are kept.

I diffed a broader well-formed battery (varied param order, quoted values containing `;`/`=`, RFC 2231 extended params, encoded-words) against `mime.ParseMediaType` — the substring dedup was the only divergence; `fixUnquotedSpecials`, `fixUnescapedQuotes` and `removeTrailingHTMLTags` matched stdlib on every well-formed input. (#401 edits the same file but a different seam — RFC 2231 multi-segment reassembly — not this dedup.)

Added `TestParseMediaType` / `TestFixMangledMediaType` cases plus an end-to-end `ReadParts` test asserting the attachment `FileName` survives. `go test ./...` passes.
