### PR TITLE
fix: call ReadPartErrorPolicy for Base64Cleaner-collected errors (#315)

### DIFF
--- a/part.go
+++ b/part.go
@@ -321,6 +321,9 @@ func (p *Part) decodeContent(r io.Reader, readPartErrorPolicy ReadPartErrorPolic
 	// Collect base64 errors.
 	if b64cleaner != nil {
 		for _, err := range b64cleaner.Errors {
+			if readPartErrorPolicy != nil && !readPartErrorPolicy(p, err) {
+				return errors.WithStack(err)
+			}
 			p.addWarning(ErrorMalformedBase64, err.Error())
 		}
 	}

--- a/part_test.go
+++ b/part_test.go
@@ -601,6 +601,34 @@ func TestReadPartErrorPolicy(t *testing.T) {
 	}
 }
 
+// TestReadPartErrorPolicyBase64Cleaner covers a different error path than
+// TestReadPartErrorPolicy above: errors collected by the internal
+// Base64Cleaner (invalid, non-alphabet bytes silently stripped from a base64
+// stream rather than surfaced as a decode error) must also be offered to the
+// configured ReadPartErrorPolicy, not unconditionally downgraded to
+// warnings. testdata/low-quality/malformed-base64-attach.raw's
+// application/msword attachment decodes successfully after cleaning
+// (`PGh0*bWw+Cg==` has a single stray `*`), so it never reaches
+// base64.CorruptInputError and previously bypassed the policy entirely.
+func TestReadPartErrorPolicyBase64Cleaner(t *testing.T) {
+	var policyCalled bool
+	rejectPolicy := enmime.ReadPartErrorPolicy(func(_ *enmime.Part, _ error) bool {
+		policyCalled = true
+		return false
+	})
+
+	r := test.OpenTestData("low-quality", "malformed-base64-attach.raw")
+	parser := enmime.NewParser(enmime.SetReadPartErrorPolicy(rejectPolicy))
+	_, err := parser.ReadParts(r)
+
+	if !policyCalled {
+		t.Error("ReadPartErrorPolicy was not called for a Base64Cleaner-collected error")
+	}
+	if err == nil {
+		t.Error("Expected ReadParts to fail since the policy returned false")
+	}
+}
+
 func TestMultiNoSkipMalformedPartFails(t *testing.T) {
 	r := test.OpenTestData("parts", "multi-malformed.raw")
 	parser := enmime.NewParser(enmime.SkipMalformedParts(false))


### PR DESCRIPTION
## Problem
Fixes #315. When a part's Content-Transfer-Encoding is base64 but the content contains stray non-base64-alphabet bytes, the internal `Base64Cleaner` silently strips them and records them in `.Errors` instead of the decoder returning a `base64.CorruptInputError`. Because decoding then succeeds, `readPartContent` (the only other call site that consults `ReadPartErrorPolicy`) never sees an error either, so a configured policy is never called for this class of malformed base64 -- even though `SetReadPartErrorPolicy`'s doc comment says it applies to any error reading part content. Confirmed on master HEAD f3d7490.

## Root cause
`part.go`, `decodeContent` (around line 321): after content is successfully read, `Base64Cleaner`'s collected errors are looped over and unconditionally turned into warnings via `p.addWarning`. `readPartErrorPolicy` is in scope (it's the function's own parameter) but was never referenced in this loop.

## Fix
Check `readPartErrorPolicy` inside the loop, same pattern already used at `readPartContent` a few lines up: if a policy is set and returns `false` for one of the collected errors, return that error (wrapped with `errors.WithStack`, matching the existing convention in this file) instead of downgrading it to a warning. 3 lines added, no API changes. When no policy is configured (`nil`, the default, and every existing caller), the new branch short-circuits and behavior is unchanged -- verified by running the full existing suite, including `TestErrorEnvelopeWarnings`'s `malformed-base64-attach.raw` case, which still passes unmodified.

## How to test
```
$ go test -run TestReadPartErrorPolicyBase64Cleaner -v .
--- FAIL: TestReadPartErrorPolicyBase64Cleaner (0.00s)   # before this fix
    part_test.go:625: ReadPartErrorPolicy was not called for a Base64Cleaner-collected error
    part_test.go:628: Expected ReadParts to fail since the policy returned false

$ go test -run TestReadPartErrorPolicyBase64Cleaner -v .
--- PASS: TestReadPartErrorPolicyBase64Cleaner (0.00s)   # after this fix
```
Added `TestReadPartErrorPolicyBase64Cleaner` in `part_test.go`, reusing the existing `testdata/low-quality/malformed-base64-attach.raw` fixture (already used by `TestErrorEnvelopeWarnings` for the no-policy case) with a policy that returns `false` and records whether it was called. Proven to bite: fails on unpatched `part.go` with the fixture in place, passes with the fix.

`go test ./...` (all 10 packages): PASS. `make lint` (`gofmt -l .` + `go vet`): clean.

## Backward compatibility
No breaking changes. Behavior only changes for callers who explicitly registered a `ReadPartErrorPolicy` -- they now get a chance to see and react to this error class, which is what registering the callback is for. Default (no policy) parsing is byte-for-byte unchanged.

---
Assisted-by: Claude (code generation, reviewed and tested locally)